### PR TITLE
compiler compatible

### DIFF
--- a/fastertransformer/utils/common.h
+++ b/fastertransformer/utils/common.h
@@ -169,7 +169,7 @@ void print_to_file(const T *result, const int size, const char *file, cudaStream
   cudaDeviceSynchronize();
   check_cuda_error(cudaGetLastError());
   printf("[INFO] file: %s with size %d.\n", file, size);
-  auto outFile = std::ofstream(file, open_mode);
+  std::ofstream outFile(file, open_mode);
   if(outFile)
   {
     T* tmp = new T[size];


### PR DESCRIPTION
Compile failed in centos gcc 4.9.2 :

/FasterTransformer/fastertransformer/utils/common.h(172): error: "std::basic_ofstream<_CharT, _Traits>::basic_ofstream(const std::basic_ofstream<char, std::char_traits<char>> &) [with _CharT=char, _Traits=std::char_traits<char>]" (declared implicitly), required for copy that was eliminated, cannot be referenced -- it is a deleted function