### PR TITLE
fix: Fix the bug of gpt pytorch wrapper

### DIFF
--- a/fastertransformer/th_op/gpt.cc
+++ b/fastertransformer/th_op/gpt.cc
@@ -127,7 +127,7 @@ std::vector<Tensor> FasterTransformerGPT::forward(Tensor start_ids, Tensor start
   attn_mask = attn_mask.to(st_);
   gpt->forward(start_ids, start_lengths, attn_mask, output_ids, output_len);
 
-  output_ids = output_ids.slice(0, 0, output_len);
+  output_ids = output_ids.slice(0, 0, input_len + output_len);
 
   return std::vector<Tensor>{output_ids};
 };


### PR DESCRIPTION
Fix the problem of returning only the first part of the input context when using python wrapper(gpt_sample.py)

location : [FasterTransformerEA/fastertransformer/th_op/gpt.cc](https://github.com/NVIDIA/FasterTransformer/blob/74847aa8fcbbe8939b7a290d6e0a4979f645fe5b/fastertransformer/th_op/gpt.cc#L130)  
```
  output_ids = output_ids.slice(0, 0, output_len); 
```
  - Since (context ids + generated token ids) is stored in output_ids, (input_len + output_len) must be entered in the 3rd argument to output all results.
