### PR TITLE
Enhancement: Allow using customized scalar for attention

### DIFF
--- a/fastertransformer/bert_encoder_transformer.h
+++ b/fastertransformer/bert_encoder_transformer.h
@@ -320,8 +320,7 @@ public:
   //allocate buffer for BertEncoderTransformer
   //do gemm test if allow_gemm_test == true
   void allocateBuffer(IAllocator *allocator, int batch_size, int from_seq_len,
-                      int to_seq_len, int head_num, int size_per_head, bool use_trt_kernel=true,
-                      float q_scaling=1.0)
+                      int to_seq_len, int head_num, int size_per_head, bool use_trt_kernel=true)
   {
 #ifndef NDEBUG
     PRINT_FUNC_NAME_();
@@ -416,7 +415,7 @@ public:
 
       //allocate buffer for attention_
       attention_->allocateBuffer(allocator, cublas_workspace_, batch_size_, from_seq_len_, to_seq_len,
-                                 head_num_, size_per_head_, hasChangedConfig, use_trt_kernel, q_scaling);
+                                 head_num_, size_per_head_, hasChangedConfig, use_trt_kernel);
     }
     catch (std::runtime_error &error)
     {

--- a/fastertransformer/bert_encoder_transformer.h
+++ b/fastertransformer/bert_encoder_transformer.h
@@ -319,8 +319,9 @@ public:
 
   //allocate buffer for BertEncoderTransformer
   //do gemm test if allow_gemm_test == true
-  void allocateBuffer(IAllocator *allocator, int batch_size, int from_seq_len, 
-                      int to_seq_len, int head_num, int size_per_head, bool use_trt_kernel=true) 
+  void allocateBuffer(IAllocator *allocator, int batch_size, int from_seq_len,
+                      int to_seq_len, int head_num, int size_per_head, bool use_trt_kernel=true,
+                      float q_scaling=1.0)
   {
 #ifndef NDEBUG
     PRINT_FUNC_NAME_();
@@ -415,7 +416,7 @@ public:
 
       //allocate buffer for attention_
       attention_->allocateBuffer(allocator, cublas_workspace_, batch_size_, from_seq_len_, to_seq_len,
-                                 head_num_, size_per_head_, hasChangedConfig, use_trt_kernel);
+                                 head_num_, size_per_head_, hasChangedConfig, use_trt_kernel, q_scaling);
     }
     catch (std::runtime_error &error)
     {
@@ -790,4 +791,3 @@ public:
 };
 
 } // namespace fastertransformer
-

--- a/fastertransformer/cuda/open_attention.h
+++ b/fastertransformer/cuda/open_attention.h
@@ -911,7 +911,7 @@ class OpenMultiHeadAttention: IMultiHeadAttention<OpType_>
         else
         {
 
-          DataType_ scalar = 1 / sqrtf(size_per_head_ * q_scaling_ * 1.0f);
+          DataType_ scalar = 1 / (sqrtf(size_per_head_ * 1.0f) * q_scaling_);
           multiHeadAttr_nofuse_kernelLauncher(
                 param_.stream,
                 param_.cublas_handle,
@@ -998,7 +998,7 @@ class OpenMultiHeadAttention: IMultiHeadAttention<OpType_>
         }
         else
         {
-          DataType_ scalar = 1 / sqrtf(size_per_head_ * q_scaling_ * 1.0f);
+          DataType_ scalar = 1 / (sqrtf(size_per_head_ * 1.0f) * q_scaling_);
 
           multiHeadAttr_nofuse_kernelLauncher(
             param_.stream,

--- a/fastertransformer/cuda/open_attention.h
+++ b/fastertransformer/cuda/open_attention.h
@@ -360,7 +360,7 @@ class OpenMultiHeadAttention: IMultiHeadAttention<OpType_>
   //allocate buffer for OpenMultiHeadAttention
   //read config again if hasChangedConfig == true
   void allocateBuffer(IAllocator* allocator, void* cublas_workspace, int batch_size, int from_seq_len, int to_seq_len,
-                      int head_num, int size_per_head, bool hasChangedConfig, bool use_trt_kernel, float q_scaling)
+                      int head_num, int size_per_head, bool hasChangedConfig, bool use_trt_kernel)
   {
 #ifndef NDEBUG
     PRINT_FUNC_NAME_();
@@ -389,7 +389,6 @@ class OpenMultiHeadAttention: IMultiHeadAttention<OpType_>
         head_num_ = head_num;
         size_per_head_ = size_per_head;
         cublas_workspace_ = cublas_workspace;
-        q_scaling_ = q_scaling
 
         const int buf_size = batch_size_ * head_num_ * from_seq_len_ * size_per_head_;
         const int qk_buf_size = batch_size_ * head_num_ * from_seq_len_ * from_seq_len_;
@@ -482,8 +481,8 @@ class OpenMultiHeadAttention: IMultiHeadAttention<OpType_>
   }
 
   //Ctor
-  OpenMultiHeadAttention(int int8_mode=0, bool allow_gemm_test=false, bool use_ORDER_COL32_2R_4R4=false, int sm = 75) : 
-    int8_mode_(int8_mode), allow_gemm_test_(allow_gemm_test), use_ORDER_COL32_2R_4R4_(use_ORDER_COL32_2R_4R4), sm_(sm)
+  OpenMultiHeadAttention(int int8_mode=0, bool allow_gemm_test=false, bool use_ORDER_COL32_2R_4R4=false, int sm = 75, float q_scaling=1.0) : 
+    int8_mode_(int8_mode), allow_gemm_test_(allow_gemm_test), use_ORDER_COL32_2R_4R4_(use_ORDER_COL32_2R_4R4), sm_(sm), q_scaling_(q_scaling)
    {
 #ifndef NDEBUG
     PRINT_FUNC_NAME_();
@@ -524,6 +523,7 @@ class OpenMultiHeadAttention: IMultiHeadAttention<OpType_>
     sm_ = attention->sm_;
     int8_mode_ = attention->int8_mode_;
     allow_gemm_test_ = attention->allow_gemm_test_;
+    q_scaling_ = attention->q_scaling_
 
     for(int i = 0; i < 2; i++) cublasBmmAlgo_[i] = attention->cublasBmmAlgo_[i];
     cublasAlgoMap_ = attention->cublasAlgoMap_;
@@ -1096,4 +1096,3 @@ class OpenMultiHeadAttention: IMultiHeadAttention<OpType_>
                                        
 }//namespace cuda
 }//namespace fastertransformer
-

--- a/fastertransformer/th_op/encoder.cc
+++ b/fastertransformer/th_op/encoder.cc
@@ -44,7 +44,8 @@ FasterTransformerEncoder::FasterTransformerEncoder(
   int64_t layer_num,
   int64_t layer_idx,
   bool allow_gemm_test,
-  bool use_trt_kernel)
+  bool use_trt_kernel,
+  double q_scaling)
 : _st(q_kernel.scalar_type()), _remove_padding(remove_padding),
   weights{q_kernel, q_bias, k_kernel, k_bias, v_kernel, v_bias,
           attr_output_kernel, attr_output_bias, attr_output_layernorm_gamma, attr_output_layernorm_beta,
@@ -88,6 +89,7 @@ FasterTransformerEncoder::FasterTransformerEncoder(
       throw std::runtime_error("Wrong Tensor type.");
   }
   head_info = torch::empty({8}, torch::dtype(torch::kInt64));
+  _q_scaling = torch::tensor({q_scaling}, torch::dtype(torch::kFloat64));
   head_info[0] = head_num;
   head_info[1] = head_size;
   head_info[2] = (int64_t)remove_padding;
@@ -124,6 +126,7 @@ Tensor FasterTransformerEncoder::forward(Tensor input, Tensor attr_mask, Tensor 
 std::vector<Tensor> FasterTransformerEncoder::get_pickle_info() const {
   std::vector<Tensor> tmp(weights);
   tmp.push_back(head_info);
+  tmp.push_back(_q_scaling)
   return tmp;
 }
 

--- a/fastertransformer/th_op/encoder.h
+++ b/fastertransformer/th_op/encoder.h
@@ -121,7 +121,7 @@ public:
     encoder_param.trt_seqlen_size = (int)trt_seqlen_offset.size(0);
     check_cuda_error(cublasSetStream(encoder_param.cublas_handle, encoder_param.stream));
     fastertransformer::Allocator<AllocatorType::TH>* allocator = new fastertransformer::Allocator<AllocatorType::TH>();
-    encoder_tmp->allocateBuffer(allocator, batch_size, seq_len, seq_len, _head_num, _head_size, _use_trt_kernel, _q_scaling);
+    encoder_tmp->allocateBuffer(allocator, batch_size, seq_len, seq_len, _head_num, _head_size, _use_trt_kernel);
     encoder_tmp->initialize(encoder_param);
     encoder_tmp->forward();
     encoder_tmp->freeBuffer();

--- a/fastertransformer/th_op/ft_op.cc
+++ b/fastertransformer/th_op/ft_op.cc
@@ -34,7 +34,7 @@ static auto fasterTransformerEncoderTHS =
   .def(torch::jit::init<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor,
                         Tensor, Tensor, Tensor, Tensor, Tensor, Tensor,
                         Tensor, Tensor, Tensor, Tensor, Tensor,
-                        int64_t, int64_t, bool, int64_t, int64_t, int64_t, bool, bool>())
+                        int64_t, int64_t, bool, int64_t, int64_t, int64_t, bool, bool, double>())
   .def("forward", &torch_ext::FasterTransformerEncoder::forward)
   .def_pickle(
     [](const c10::intrusive_ptr<torch_ext::FasterTransformerEncoder>& self) -> std::vector<Tensor> {
@@ -49,11 +49,20 @@ static auto fasterTransformerEncoderTHS =
       int64_t layer_idx = state[17][5].item().to<int>();
       bool allow_gemm_test = (bool)(state[17][6].item().to<int>());
       bool use_trt_kernel = (bool)(state[17][7].item().to<int>());
+
+      // For backward compatibility, we set q_scaling to 1.0 for the model created before
+      // adding this field.
+      double q_scaling = 1.0;
+      if (state.size() > 18) {
+        q_scaling = (state[18][0].item().to<double>());
+      }
+
       return c10::make_intrusive<torch_ext::FasterTransformerEncoder>(
         state[0], state[1], state[2], state[3], state[4], state[5],
         state[6], state[7], state[8], state[9], state[10], state[11],
         state[12], state[13], state[14], state[15], state[16],
-        head_num, head_size, remove_padding, int8_mode, layer_num, layer_idx, allow_gemm_test, use_trt_kernel);
+        head_num, head_size, remove_padding, int8_mode, layer_num, layer_idx,
+        allow_gemm_test, use_trt_kernel, q_scaling);
     }
   );
 

--- a/fastertransformer/trt_fused_multihead_attention/qkvToContext.cu
+++ b/fastertransformer/trt_fused_multihead_attention/qkvToContext.cu
@@ -208,7 +208,7 @@ private:
 };
 
 FusedMHARunnerFP16v2::FusedMHARunnerFP16v2(const int numHeads, const int headSize, const int sm)
-    : MHARunner(numHeads, headSize, 2)
+    : MHARunner(numHeads, headSize, 2, q_scaling)
     , mSm(sm)
     , pimpl(new mhaImpl(this))
 {

--- a/fastertransformer/trt_fused_multihead_attention/qkvToContext.h
+++ b/fastertransformer/trt_fused_multihead_attention/qkvToContext.h
@@ -37,7 +37,7 @@ namespace fastertransformer
 class MHARunner
 {
 public:
-    MHARunner(const int numHeads, const int headSize, const int wordSize, const float q_scaling)
+    MHARunner(const int numHeads, const int headSize, const int wordSize, const float q_scaling=1.0f)
         : mS(0)
         , mB(0)
         , mOmatSize(0)
@@ -49,7 +49,7 @@ public:
         , mStrideQKV(0)
         , mLdOut(0)
         , mStrideOut(0)
-        , mRsqrtHeadSize(1.f / sqrtf(headSize * q_scaling))
+        , mRsqrtHeadSize(1.f / (sqrtf(headSize) * q_scaling))
     {
     }
 

--- a/fastertransformer/trt_fused_multihead_attention/qkvToContext.h
+++ b/fastertransformer/trt_fused_multihead_attention/qkvToContext.h
@@ -37,7 +37,7 @@ namespace fastertransformer
 class MHARunner
 {
 public:
-    MHARunner(const int numHeads, const int headSize, const int wordSize)
+    MHARunner(const int numHeads, const int headSize, const int wordSize, const float q_scaling)
         : mS(0)
         , mB(0)
         , mOmatSize(0)
@@ -49,7 +49,7 @@ public:
         , mStrideQKV(0)
         , mLdOut(0)
         , mStrideOut(0)
-        , mRsqrtHeadSize(1.f / sqrtf(headSize))
+        , mRsqrtHeadSize(1.f / sqrtf(headSize * q_scaling))
     {
     }
 
@@ -101,7 +101,7 @@ protected:
 class FusedMHARunnerFP16v2 : public MHARunner
 {
 public:
-    FusedMHARunnerFP16v2(const int numHeads, const int headSize, const int sm);
+    FusedMHARunnerFP16v2(const int numHeads, const int headSize, const int sm, const float q_scaling);
     ~FusedMHARunnerFP16v2() = default; // for pimpl
 
     virtual void setup(const int S, const int B) override;


### PR DESCRIPTION
The third enhancement mentioned in https://github.com/NVIDIA/FasterTransformer/issues/98. 

Add support for customizing scalar in OpenMultiHeadAttention. Sometimes models may have large projection weights for query and could lead to overflow in fp16. To prevent this we can scale the q_proj weights beforehand and adjust the scalar used in forward accordingly.