### PR TITLE
[Enhancement] Allow Bert Encoder to specify hidden dime for the fc layers

### DIFF
--- a/fastertransformer/bert_encoder_transformer.h
+++ b/fastertransformer/bert_encoder_transformer.h
@@ -732,9 +732,9 @@ public:
 #endif
 
         n = mlp_hidden_dim_;
-
-        cublasMM_cublasLtMM_wrapper(param_.cublaslt_handle, param_.cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N,
-                                    n, m, k, &alpha,
+    
+        cublasMM_cublasLtMM_wrapper(param_.cublaslt_handle, param_.cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N, 
+                                    n, m, k, &alpha, 
                                     param_.ffn.intermediate_weight.kernel, AType_, n,
                                     attr_matmul_buf_, BType_, k, 
                                     &beta, (DataType_ *)inter_matmul_buf_, CType_, n,
@@ -749,9 +749,9 @@ public:
 
         n = k;
         k = mlp_hidden_dim_;
-
-        cublasMM_cublasLtMM_wrapper(param_.cublaslt_handle, param_.cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N,
-                                    n, m, k, &alpha,
+    
+        cublasMM_cublasLtMM_wrapper(param_.cublaslt_handle, param_.cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N, 
+                                    n, m, k, &alpha, 
                                     param_.ffn.output_weight.kernel, AType_, n,
                                     inter_matmul_buf_, BType_, k, 
                                     &beta, (DataType_ *)(param_.transformer_out), CType_, n,

--- a/fastertransformer/bert_encoder_transformer.h
+++ b/fastertransformer/bert_encoder_transformer.h
@@ -356,7 +356,7 @@ public:
         int n = k;
 
         int buf_size = m * n;
-        size_t buf_size_in_byte = calBufSizeInByte(batch_size_, from_seq_len_, head_num_, size_per_head_, int8_mode_);
+        size_t buf_size_in_byte = calBufSizeInByte(batch_size_, from_seq_len_, head_num_, size_per_head_, mlp_hidden_dim_, int8_mode_);
         
         //allocate buffer
         if (int8_mode_ != 0){

--- a/fastertransformer/bert_encoder_transformer.h
+++ b/fastertransformer/bert_encoder_transformer.h
@@ -115,6 +115,7 @@ class BertEncoderTransformer
   int to_seq_len_;
   int head_num_;
   int size_per_head_;
+  int mlp_hidden_dim_;
 
   int sm_;
   bool allow_gemm_test_ = false;
@@ -144,7 +145,7 @@ public:
     layer_idx_ = layer_idx;
   }
 
-  size_t calBufSizeInByte(int batch_size, int seq_len, int head_num, int size_per_head, int int8_mode){
+  size_t calBufSizeInByte(int batch_size, int seq_len, int head_num, int size_per_head, int mlp_hidden_dim, int int8_mode){
     size_t m = batch_size*seq_len;
     size_t n = head_num*size_per_head;
     size_t k = n;
@@ -156,15 +157,15 @@ public:
                          m*k*sizeof(int8_t) +
                          //int8 qkv weight
                          3*n*k*sizeof(int8_t) +
-                         //FC0 & FC1 & FC2 for m*k(4k)*sizeof(DataType)
-                         4*m*k * sizeof(int) +
+                         //FC0 & FC1 & FC2 for m*mlp_hidden_dim*sizeof(DataType)
+                         m*mlp_hidden_dim * sizeof(int) +
                          //attr_out_buf_ & attr_matmul_buf_ & inter_matmul_buf_
                          6*m*n*sizeof(DataType_) +
                          //temp buf
                          m*n*sizeof(DataType_);
     }
     else{
-      normal_buf_size = sizeof(DataType_) * (m*n) * 7 + ((sizeof(half) == sizeof(DataType_)) ? CUBLAS_WORKSPACE_SIZE : 0);
+      normal_buf_size = sizeof(DataType_) * ((m*n) * 3 + m*mlp_hidden_dim) + ((sizeof(half) == sizeof(DataType_)) ? CUBLAS_WORKSPACE_SIZE : 0);
     }
     return normal_buf_size;  
   }
@@ -319,8 +320,9 @@ public:
 
   //allocate buffer for BertEncoderTransformer
   //do gemm test if allow_gemm_test == true
-  void allocateBuffer(IAllocator *allocator, int batch_size, int from_seq_len, 
-                      int to_seq_len, int head_num, int size_per_head, bool use_trt_kernel=true) 
+  void allocateBuffer(IAllocator *allocator, int batch_size, int from_seq_len,
+                      int to_seq_len, int head_num, int size_per_head, int mlp_hidden_dim,
+                      bool use_trt_kernel=true)
   {
 #ifndef NDEBUG
     PRINT_FUNC_NAME_();
@@ -347,6 +349,7 @@ public:
         to_seq_len_ = to_seq_len;
         head_num_ = head_num;
         size_per_head_ = size_per_head;
+        mlp_hidden_dim_ = mlp_hidden_dim;
 
         int m = batch_size_ * from_seq_len_;
         int k = head_num_ * size_per_head_;
@@ -631,8 +634,8 @@ public:
         check_cuda_error(cudaGetLastError());
 #endif
 
-        n *= 4;
-        
+        n = mlp_hidden_dim_;
+
         if (int8_mode_ == 1){
           quantized_kernelLauncher(attr_matmul_buf_tmp_, attr_matmul_buf_, k*m, ProjBiasNorm_amax_ptr + 3, param_.stream);
           cublasLtMM_withAlgo(int_buf_, 1, m, n, k, m*k, n*k, m*n, 
@@ -658,8 +661,8 @@ public:
 #endif
 
         n = k;
-        k *= 4;
-        
+        k = mlp_hidden_dim_;
+
         if (int8_mode_ == 1)
         {
           cublasLtMM_withAlgo(int_buf_, 1, m, n, k, m*k, n*k, m*n, 
@@ -728,10 +731,10 @@ public:
         check_cuda_error(cudaGetLastError());
 #endif
 
-        n *= 4;
-        
-        cublasMM_cublasLtMM_wrapper(param_.cublaslt_handle, param_.cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N, 
-                                    n, m, k, &alpha, 
+        n = mlp_hidden_dim_;
+
+        cublasMM_cublasLtMM_wrapper(param_.cublaslt_handle, param_.cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N,
+                                    n, m, k, &alpha,
                                     param_.ffn.intermediate_weight.kernel, AType_, n,
                                     attr_matmul_buf_, BType_, k, 
                                     &beta, (DataType_ *)inter_matmul_buf_, CType_, n,
@@ -745,10 +748,10 @@ public:
 #endif
 
         n = k;
-        k *= 4;
-        
-        cublasMM_cublasLtMM_wrapper(param_.cublaslt_handle, param_.cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N, 
-                                    n, m, k, &alpha, 
+        k = mlp_hidden_dim_;
+
+        cublasMM_cublasLtMM_wrapper(param_.cublaslt_handle, param_.cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N,
+                                    n, m, k, &alpha,
                                     param_.ffn.output_weight.kernel, AType_, n,
                                     inter_matmul_buf_, BType_, k, 
                                     &beta, (DataType_ *)(param_.transformer_out), CType_, n,
@@ -790,4 +793,3 @@ public:
 };
 
 } // namespace fastertransformer
-

--- a/fastertransformer/tf_op/bert_transformer_op.cc
+++ b/fastertransformer/tf_op/bert_transformer_op.cc
@@ -186,7 +186,8 @@ public:
                                            from_seq_len_,
                                            to_seq_len_,
                                            head_num_,
-                                           size_per_head_
+                                           size_per_head_,
+                                           4 * head_num_ * size_per_head_,
                                            );
       encoder_transformer_tmp->initialize(param);
       encoder_transformer_tmp->forward();
@@ -624,7 +625,8 @@ public:
                                            from_seq_len_,
                                            to_seq_len_,
                                            head_num_,
-                                           size_per_head_
+                                           size_per_head_,
+                                           4 * head_num_ * size_per_head_,
                                            );
       encoder_transformer_->initialize(param);
       encoder_transformer_->forward();
@@ -668,4 +670,3 @@ REGISTER_GPU(Eigen::half);
 
 } //namespace
 } //namespace tensorflow
-

--- a/fastertransformer/th_op/encoder.h
+++ b/fastertransformer/th_op/encoder.h
@@ -50,8 +50,9 @@ template <typename T>
 class FTEncoder : public IFTEncoder {
 public:
   FTEncoder(int head_num, int head_size,
-            int int8_mode, int layer_num, int layer_idx, bool allow_gemm_test, bool use_trt_kernel,
-            const std::vector<Tensor>& w) : _head_num(head_num), _head_size(head_size), _use_trt_kernel(use_trt_kernel), _weights(w) {
+            int int8_mode, int layer_num, int layer_idx, bool allow_gemm_test, bool use_trt_kernel, int mlp_hidden_dim,
+            const std::vector<Tensor>& w) : _head_num(head_num), _head_size(head_size), _use_trt_kernel(use_trt_kernel),
+            _mlp_hidden_dim(mlp_hidden_dim), _weights(w) {
     int hidden_dim = _head_num * _head_size;
     check_cuda_error(cublasCreate(&_cublasHandle));
     check_cuda_error(cublasLtCreate(&_cublasltHandle));
@@ -120,7 +121,7 @@ public:
     encoder_param.trt_seqlen_size = (int)trt_seqlen_offset.size(0);
     check_cuda_error(cublasSetStream(encoder_param.cublas_handle, encoder_param.stream));
     fastertransformer::Allocator<AllocatorType::TH>* allocator = new fastertransformer::Allocator<AllocatorType::TH>();
-    encoder_tmp->allocateBuffer(allocator, batch_size, seq_len, seq_len, _head_num, _head_size, _use_trt_kernel);
+    encoder_tmp->allocateBuffer(allocator, batch_size, seq_len, seq_len, _head_num, _head_size, _use_trt_kernel, _mlp_hidden_dim);
     encoder_tmp->initialize(encoder_param);
     encoder_tmp->forward();
     encoder_tmp->freeBuffer();

--- a/fastertransformer/th_op/encoder.h
+++ b/fastertransformer/th_op/encoder.h
@@ -138,6 +138,7 @@ private:
   BertInitParam<T> encoder_param;
   BertEncoderTransformer<EncoderTraits_>* encoder = nullptr;
   bool _use_trt_kernel;
+  const int _mlp_hidden_dim;
 };
 
 template <typename T>
@@ -228,7 +229,8 @@ public:
     int64_t layer_num,
     int64_t layer_idx,
     bool allow_gemm_test,
-    bool use_trt_kernel);
+    bool use_trt_kernel,
+    int64_t _mlp_hidden_dim);
 
   ~FasterTransformerEncoder();
   

--- a/fastertransformer/th_op/ft_op.cc
+++ b/fastertransformer/th_op/ft_op.cc
@@ -34,7 +34,7 @@ static auto fasterTransformerEncoderTHS =
   .def(torch::jit::init<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor,
                         Tensor, Tensor, Tensor, Tensor, Tensor, Tensor,
                         Tensor, Tensor, Tensor, Tensor, Tensor,
-                        int64_t, int64_t, bool, int64_t, int64_t, int64_t, bool, bool>())
+                        int64_t, int64_t, bool, int64_t, int64_t, int64_t, bool, bool, int64_t>())
   .def("forward", &torch_ext::FasterTransformerEncoder::forward)
   .def_pickle(
     [](const c10::intrusive_ptr<torch_ext::FasterTransformerEncoder>& self) -> std::vector<Tensor> {
@@ -49,11 +49,12 @@ static auto fasterTransformerEncoderTHS =
       int64_t layer_idx = state[17][5].item().to<int>();
       bool allow_gemm_test = (bool)(state[17][6].item().to<int>());
       bool use_trt_kernel = (bool)(state[17][7].item().to<int>());
+      int64_t mlp_hidden_dim = state[17].size(0) >= 9 ? state[17][8].item().to<int>() : 4 * head_num * head_size;
       return c10::make_intrusive<torch_ext::FasterTransformerEncoder>(
         state[0], state[1], state[2], state[3], state[4], state[5],
         state[6], state[7], state[8], state[9], state[10], state[11],
         state[12], state[13], state[14], state[15], state[16],
-        head_num, head_size, remove_padding, int8_mode, layer_num, layer_idx, allow_gemm_test, use_trt_kernel);
+        head_num, head_size, remove_padding, int8_mode, layer_num, layer_idx, allow_gemm_test, use_trt_kernel, mlp_hidden_dim);
     }
   );
 

--- a/sample/cpp/encoder_sample.cc
+++ b/sample/cpp/encoder_sample.cc
@@ -62,7 +62,7 @@ int main(int argc, char* argv[])
   int head_num = atoi(argv[4]);
   int size_per_head = atoi(argv[5]);
   bool is_remove_padding = (bool)atoi(argv[7]);
-  int int8_mode = atoi(argv[8]);    
+  int int8_mode = atoi(argv[8]);      
 
   if(atoi(argv[6]) == 0)
     encoder_sample<float>(batch_size, num_layers, seq_len, head_num, size_per_head, is_remove_padding, int8_mode, allow_gemm_test);
@@ -369,7 +369,7 @@ void encoder_sample(int batch_size,
     
     if(is_remove_padding == true)
     {
-      rebuild_sequence_length_padding_kernelLauncher(d_transformer_out, d_transformer_out_with_padding,
+      rebuild_sequence_length_padding_kernelLauncher(d_transformer_out, d_transformer_out_with_padding, 
                                                       d_sequence_id_offset,
                                                       encoder_param.valid_word_num, hidden_dim,
                                                       encoder_param.stream);

--- a/sample/cpp/encoder_sample.cc
+++ b/sample/cpp/encoder_sample.cc
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
   printf("Device %s\n", prop.name);
   bool allow_gemm_test = false;
   if (argc >= 10)
-    allow_gemm_test = (atoi(argv[9]) == 1) ? true : false;
+    allow_gemm_test = (atoi(argv[9]) == 1) ? true : false; 
 
   printf("Device %s\n", prop.name);
   int batch_size = atoi(argv[1]);
@@ -62,7 +62,7 @@ int main(int argc, char* argv[])
   int head_num = atoi(argv[4]);
   int size_per_head = atoi(argv[5]);
   bool is_remove_padding = (bool)atoi(argv[7]);
-  int int8_mode = atoi(argv[8]);
+  int int8_mode = atoi(argv[8]);    
 
   if(atoi(argv[6]) == 0)
     encoder_sample<float>(batch_size, num_layers, seq_len, head_num, size_per_head, is_remove_padding, int8_mode, allow_gemm_test);
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
     printf("[ERROR] is_fp16 should be 0 (use float) or 1 (use half). \n");
     return -1;
   }
-
+  
   return 0;
 }
 
@@ -104,7 +104,7 @@ void device_malloc_one(T **ptr, int batchSize, int seqLen, int avg_len)
     {
       for (int l2 = 0 ; l2 < avg_len ; l2++)
         tmp[j++] = (T)(1.0f);
-      for (int l2 = avg_len ; l2 < seqLen ; l2++)
+      for (int l2 = avg_len ; l2 < seqLen ; l2++) 
         tmp[j++] = T(0.0f);
     }
   }
@@ -137,7 +137,7 @@ void encoder_sample(int batch_size,
   T *d_output_kernel = NULL, *d_output_bias = NULL, *d_output_layernorm_beta = NULL, *d_output_layernorm_gamma = NULL;
   float *amaxList = NULL;
   int* d_trt_seqlen_offset = NULL;
-
+  
   // pre_process buffer
   T *d_from_tensor_with_padding = NULL;
   T *d_transformer_out_with_padding = NULL;
@@ -169,7 +169,7 @@ void encoder_sample(int batch_size,
     }
     cudaMalloc(&d_trt_seqlen_offset, sizeof(int) * (h_trt_seqlen_size));
     cudaMemcpy(d_trt_seqlen_offset, h_trt_seqlen_offset, sizeof(int) * (h_trt_seqlen_size), cudaMemcpyHostToDevice);
-    device_malloc_one(&d_attr_mask, batch_size, seq_len, seq_len/2);
+    device_malloc_one(&d_attr_mask, batch_size, seq_len, seq_len/2);    
     delete [] h_trt_seqlen_offset;
   }
   else
@@ -279,7 +279,7 @@ void encoder_sample(int batch_size,
   encoder_param.trt_seqlen_offset = d_trt_seqlen_offset;
   encoder_param.trt_seqlen_size = h_trt_seqlen_size;
 
-  BertEncoderTransformer<EncoderTraits_> *encoder_transformer_ =
+  BertEncoderTransformer<EncoderTraits_> *encoder_transformer_ = 
           new BertEncoderTransformer<EncoderTraits_>(int8_mode, allow_gemm_test);
 
   encoder_transformer_->allocateBuffer(&allocator, batch_size, from_seq_len, to_seq_len, head_num, size_per_head, 4 * head_num * size_per_head);
@@ -294,19 +294,19 @@ void encoder_sample(int batch_size,
     {
       cudaMemcpyAsync(d_sequence_length, h_sequence_length, sizeof(int) * batch_size, cudaMemcpyHostToDevice, stream);
       int* h_valid_word_num = new int[1];
-      build_sequence_length_padding_offset_kernelLauncher(d_sequence_length,
+      build_sequence_length_padding_offset_kernelLauncher(d_sequence_length, 
             batch_size, seq_len, d_valid_word_num, d_tmp_sequence_id_offset, stream);
       cudaMemcpyAsync(h_valid_word_num, d_valid_word_num, sizeof(int), cudaMemcpyDeviceToHost, stream);
       const int valid_word_num = h_valid_word_num[0];
       delete h_valid_word_num;
 
-      remove_sequence_length_padding_kernelLauncher(d_from_tensor_with_padding,
+      remove_sequence_length_padding_kernelLauncher(d_from_tensor_with_padding, 
                                                     d_from_tensor,
                                                     d_tmp_sequence_id_offset,
-                                                    d_sequence_id_offset,
+                                                    d_sequence_id_offset, 
                                                     valid_word_num, hidden_dim,
                                                     stream);
-
+      
       encoder_param.sequence_id_offset = d_sequence_id_offset;
       encoder_param.valid_word_num = valid_word_num;
     }
@@ -314,21 +314,21 @@ void encoder_sample(int batch_size,
     {
       encoder_param.valid_word_num = batch_size * seq_len;
     }
-
+    
 
     encoder_transformer_->initialize(encoder_param);
     for(int i = 0; i < num_layers; i++)
       encoder_transformer_->forward();
-
+    
     if(is_remove_padding == true)
     {
-      rebuild_sequence_length_padding_kernelLauncher(d_transformer_out, d_transformer_out_with_padding,
-                                                      d_sequence_id_offset,
+      rebuild_sequence_length_padding_kernelLauncher(d_transformer_out, d_transformer_out_with_padding, 
+                                                      d_sequence_id_offset, 
                                                       encoder_param.valid_word_num, hidden_dim,
                                                       encoder_param.stream);
     }
   }
-
+  
   struct timeval start, end;
   cudaDeviceSynchronize();
   cudaProfilerStart();
@@ -339,19 +339,19 @@ void encoder_sample(int batch_size,
     {
       cudaMemcpyAsync(d_sequence_length, h_sequence_length, sizeof(int) * batch_size, cudaMemcpyHostToDevice, stream);
       int* h_valid_word_num = new int[1];
-      build_sequence_length_padding_offset_kernelLauncher(d_sequence_length,
+      build_sequence_length_padding_offset_kernelLauncher(d_sequence_length, 
             batch_size, seq_len, d_valid_word_num, d_tmp_sequence_id_offset, stream);
       cudaMemcpyAsync(h_valid_word_num, d_valid_word_num, sizeof(int), cudaMemcpyDeviceToHost, stream);
       const int valid_word_num = h_valid_word_num[0];
       delete h_valid_word_num;
 
-      remove_sequence_length_padding_kernelLauncher(d_from_tensor_with_padding,
+      remove_sequence_length_padding_kernelLauncher(d_from_tensor_with_padding, 
                                                     d_from_tensor,
                                                     d_tmp_sequence_id_offset,
-                                                    d_sequence_id_offset,
+                                                    d_sequence_id_offset, 
                                                     valid_word_num, hidden_dim,
                                                     stream);
-
+      
       encoder_param.sequence_id_offset = d_sequence_id_offset;
       encoder_param.valid_word_num = valid_word_num;
     }
@@ -366,7 +366,7 @@ void encoder_sample(int batch_size,
       encoder_transformer_->initialize(encoder_param);
       encoder_transformer_->forward();
     }
-
+    
     if(is_remove_padding == true)
     {
       rebuild_sequence_length_padding_kernelLauncher(d_transformer_out, d_transformer_out_with_padding,
@@ -375,13 +375,13 @@ void encoder_sample(int batch_size,
                                                       encoder_param.stream);
     }
   }
-
+  
 
   cudaDeviceSynchronize();
   gettimeofday(&end, NULL);
   cudaProfilerStop();
 
-  printf("[INFO] batch_size %d seq_len %d layer %d FT-CPP-time %.2f ms ( %d iterations) \n", batch_size, seq_len, num_layers,
+  printf("[INFO] batch_size %d seq_len %d layer %d FT-CPP-time %.2f ms ( %d iterations) \n", batch_size, seq_len, num_layers, 
           ((end.tv_sec - start.tv_sec) * 1000 + (end.tv_usec - start.tv_usec) * 0.001) / ite, ite);
 
   delete encoder_transformer_;

--- a/sample/pytorch/utils/encoder.py
+++ b/sample/pytorch/utils/encoder.py
@@ -171,13 +171,17 @@ class CustomEncoder(torch.nn.Module):
                 self.encoders.append(
                     torch.classes.FasterTransformer.Encoder(
                         *weights.listed_weights(i),
-                        head_num, head_size, remove_padding, int8_mode, layer_num, i, allow_gemm_test, use_trt_kernel))
+                        head_num, head_size, remove_padding, 
+                        int8_mode, layer_num, i, allow_gemm_test, 
+                        use_trt_kernel, 4 * head_num * head_size))
             except:
                 # legacy ths for 20.03 image
                 self.encoders.append(
                     torch.classes.FasterTransformerEncoder(
                         *weights.listed_weights(i),
-                        head_num, head_size, remove_padding, int8_mode, layer_num, i, allow_gemm_test, use_trt_kernel))
+                        head_num, head_size, remove_padding, 
+                        int8_mode, layer_num, i, allow_gemm_test, 
+                        use_trt_kernel, 4 * head_num * head_size))
         self.build_mask_remove_padding = torch.ops.fastertransformer.build_mask_remove_padding
         self.rebuild_padding = torch.ops.fastertransformer.rebuild_padding
 

--- a/sample/pytorch/utils/encoder.py
+++ b/sample/pytorch/utils/encoder.py
@@ -173,7 +173,7 @@ class CustomEncoder(torch.nn.Module):
                         *weights.listed_weights(i),
                         head_num, head_size, remove_padding, 
                         int8_mode, layer_num, i, allow_gemm_test, 
-                        use_trt_kernel, 4 * head_num * head_size))
+                        use_trt_kernel, 1.0, 4 * head_num * head_size))
             except:
                 # legacy ths for 20.03 image
                 self.encoders.append(
@@ -181,7 +181,7 @@ class CustomEncoder(torch.nn.Module):
                         *weights.listed_weights(i),
                         head_num, head_size, remove_padding, 
                         int8_mode, layer_num, i, allow_gemm_test, 
-                        use_trt_kernel, 4 * head_num * head_size))
+                        use_trt_kernel, 1.0, 4 * head_num * head_size))
         self.build_mask_remove_padding = torch.ops.fastertransformer.build_mask_remove_padding
         self.rebuild_padding = torch.ops.fastertransformer.rebuild_padding
 


### PR DESCRIPTION
This was the second enhancement in https://github.com/NVIDIA/FasterTransformer/issues/98.

Add support for different hidden dimension size in bert's fc layers. Currently in bert encoder feed forward part, the hidden dim of the first fc is hardcoded to 4 * head_dim * head_size. This PR added a field to pass in the size of hidden dimension.