### PR TITLE
fix: Add q_scaling as input for pytorch op

### DIFF
--- a/sample/pytorch/utils/encoder.py
+++ b/sample/pytorch/utils/encoder.py
@@ -171,13 +171,13 @@ class CustomEncoder(torch.nn.Module):
                 self.encoders.append(
                     torch.classes.FasterTransformer.Encoder(
                         *weights.listed_weights(i),
-                        head_num, head_size, remove_padding, int8_mode, layer_num, i, allow_gemm_test, use_trt_kernel))
+                        head_num, head_size, remove_padding, int8_mode, layer_num, i, allow_gemm_test, use_trt_kernel, 1.0))
             except:
                 # legacy ths for 20.03 image
                 self.encoders.append(
                     torch.classes.FasterTransformerEncoder(
                         *weights.listed_weights(i),
-                        head_num, head_size, remove_padding, int8_mode, layer_num, i, allow_gemm_test, use_trt_kernel))
+                        head_num, head_size, remove_padding, int8_mode, layer_num, i, allow_gemm_test, use_trt_kernel, 1.0))
         self.build_mask_remove_padding = torch.ops.fastertransformer.build_mask_remove_padding
         self.rebuild_padding = torch.ops.fastertransformer.rebuild_padding
 


### PR DESCRIPTION
Note that we don't set the q_scaling into bert_encoder_transformer.h and
hence it is still useless because we cannot set the q_scaling from outside.