### PR TITLE
make TFusedMHAKernelFactory thread_local

### DIFF
--- a/fastertransformer/trt_fused_multihead_attention/fused_multihead_attention.h
+++ b/fastertransformer/trt_fused_multihead_attention/fused_multihead_attention.h
@@ -313,7 +313,7 @@ public:
 
     static TFusedMHAKernelFactory<TFusedMHAKernelList>& Get()
     {
-        static TFusedMHAKernelFactory<TFusedMHAKernelList> s_factory;
+        thread_local TFusedMHAKernelFactory<TFusedMHAKernelList> s_factory;
         return s_factory;
     }
 


### PR DESCRIPTION
## issue
when running faster transformer with multiple threads, where each thread corresponds to a different GPU, and use_trt_kernels=true, kernel launch would throw CUDA_ERROR_INVALID_HANDLE. there will always be 1 out of all GPUs running fine.

## cause
the custom kernels (and hence the CUFunction handles) were dynamically loaded and would be dropped during driver context switch for different threads.

## solution
making the factory object thread_local so that each thread will have a copy of the custom kernels in memory.