### PR TITLE
fix a bug in sample code

### DIFF
--- a/bert-quantization/bert-pyt-quantization/README.md
+++ b/bert-quantization/bert-pyt-quantization/README.md
@@ -68,7 +68,7 @@ python -m torch.distributed.launch --nproc_per_node=8 run_squad.py \
   --output_dir=$MODEL_DIR/bert-base-uncased-finetuned \
   --max_steps=-1 \
   --fp16 \
-  --quant_disable
+  --quant-disable
 ```
 
 The results would be like:


### PR DESCRIPTION
In `quant_utils.py`, the [definition](https://github.com/NVIDIA/FasterTransformer/blob/main/bert-quantization/bert-pyt-quantization/quant_utils.py#L51) for this augment is
```
group.add_argument('--quant-disable', action='store_true',
                        help='disable all quantizers')
```
Current sample code using `--quant_disable`, which will cause error message `run_squad.py: error: unrecognized arguments: --quant_disable`.

I remembered maybe I run successfully with `--quant_disable` once but this *might* rely on different versions of packages.
A better way is to avoid this by using `--quant-disable`, which is the same as the definition.
