### PR TITLE
Add support for head_dim > 1024 for fp16, no whitespace change

### DIFF
--- a/fastertransformer/cuda/attention_kernels.cu
+++ b/fastertransformer/cuda/attention_kernels.cu
@@ -290,7 +290,7 @@ void add_QKV_bias_transpose_kernelLauncher(
     if(sizeof(T) == 4)
     {
       const int m = batch_size * seq_len;
-      const int word_per_block = 4;
+      const int word_per_block = 1;
       dim3 block;
       if(k % 512 == 0)
         block.x = 512;
@@ -312,7 +312,7 @@ void add_QKV_bias_transpose_kernelLauncher(
     else
     {
       const int m = batch_size * seq_len;
-      const int word_per_block = 4;
+      const int word_per_block = 1;
       const int half_k = k / 2;
       dim3 block;
       if(half_k % 512 == 0)


### PR DESCRIPTION
Thanks to @842974287 's implementation.
Add head_dim > 1024 for fp16 in
add_QKV_bias_rebuild_padding
add_bias_input_layernorm

For the comments in https://github.com/842974287/FasterTransformer/commit/dacb3ceed52d6cdb59f10adc6fa02f615da9084a

1. When word_per_block != 1, dim3 grid(m * half_k / block.x / word_per_block * 3); could generate remainder, which might cause problem.
2. This diff now contains the implementation of add_bias_input_layernorm when headdim > 1024.

Please let me know if this pr is good for commit, or we need to modify. Thanks!