### PR TITLE
update flags for profile_bert_inference

### DIFF
--- a/sample/tensorflow/tensorflow_bert/profile_bert_inference.py
+++ b/sample/tensorflow/tensorflow_bert/profile_bert_inference.py
@@ -193,4 +193,7 @@ if __name__ == "__main__":
     flags.mark_flag_as_required("xla")
     flags.DEFINE_bool("tf_profile", False,
                       "whether to use tensorflow profiling")
+    flags.DEFINE_bool("remove_padding", False, "Whether remove the padding of sentences")
+    flags.DEFINE_integer("int8_mode", 0, "whether use int8 or not; and how to use int8")
+    flags.DEFINE_bool("allow_gemm_test", False, "whether allow gemm test inside FT.")
     tf.app.run()


### PR DESCRIPTION
as the 3 flags ( 'int8_mode', 'remove_padding', and 'allow_gemm_test') are used by fast_infer_util.py, they are need to be defined in the profile_bert_inference.py.