### PR TITLE
Fix sampling float16

### DIFF
--- a/fastertransformer/cuda/topk_kernels.cu
+++ b/fastertransformer/cuda/topk_kernels.cu
@@ -388,7 +388,7 @@ __global__ void topk_stage_2_opt3_sampling(const int* __restrict topk_tmp_id_buf
         for(int i = 0; i < k; i++)
         {
             rand_num = rand_num - (float)s_val2[s_id[i]];
-            if(rand_num <= 0.0f)
+            if(rand_num <= 0.0f || k - 1 == i)
             {
                 ids[batch_id] = topk_tmp_id_buf[batch_id * size + s_id[i]]  % vocab_size;
                 break;
@@ -1455,7 +1455,7 @@ __global__ void topk_topp_sampling_kernel_v2(const int* __restrict topk_tmp_id_b
         for(int i = 0; i < k; i++)
         {
             rand_num = rand_num - (float)s_val2[s_id[i]];
-            if(rand_num <= 0.0f)
+            if(rand_num <= 0.0f || k - 1 == i)
             {
                 ids[batch_id] = topk_tmp_id_buf[batch_id * size + s_id[i]]  % vocab_size;
                 break;


### PR DESCRIPTION
When using sampling strategy with float16, the condition `rand_num <= 0.0f` may not be meet even if after `k` iterations and corresponding `ids` may get a strange number. 
This won't cause the program exit, but it's the reason why post-process fails.

We initialize `curandstate` with `clock()` rather than `0` and run into this problem.

Average generation length: 20
Num of samples: 5000
Failed: 1