### PR TITLE
Fix runtime errors on gptj example

### DIFF
--- a/examples/cpp/gptj/gptj_example.cc
+++ b/examples/cpp/gptj/gptj_example.cc
@@ -338,13 +338,17 @@ void gptj_example(const INIReader reader)
         // prefix_prompt_task_ids.data()}},
         {"output_seq_len",
          Tensor{MEMORY_CPU, TYPE_UINT32, std::vector<size_t>{request_batch_size}, output_seq_len.data()}},
-        {"bad_words_list", Tensor{MEMORY_GPU, TYPE_INT32, {2, bad_words.size() / 2}, d_bad_words}},
-        {"stop_words_list", Tensor{MEMORY_GPU, TYPE_INT32, {request_batch_size, 2, stop_words_len}, d_stop_words}},
         {"temperature", Tensor{MEMORY_CPU, TYPE_FP32, std::vector<size_t>{1}, &temperature}},
         {"len_penalty", Tensor{MEMORY_CPU, TYPE_FP32, std::vector<size_t>{1}, &len_penalty}},
         {"repetition_penalty", Tensor{MEMORY_CPU, TYPE_FP32, std::vector<size_t>{1}, &repetition_penalty}},
         {"start_id", Tensor{MEMORY_CPU, TYPE_INT32, std::vector<size_t>{request_batch_size}, start_ids.data()}},
         {"end_id", Tensor{MEMORY_CPU, TYPE_INT32, std::vector<size_t>{request_batch_size}, end_ids.data()}}};
+    if (!bad_words.empty()) {
+        input_tensors.insert({"bad_words_list", Tensor{MEMORY_GPU, TYPE_INT32, {2, bad_words.size() / 2}, d_bad_words}});
+    }
+    if (stop_words_len != 0) {
+        input_tensors.insert({"stop_words_list", Tensor{MEMORY_GPU, TYPE_INT32, {request_batch_size, 2, stop_words_len}, d_stop_words}});
+    }
     if (top_k == 0 && top_p == 0.0f) {
         FT_CHECK(beam_width > 1);
         input_tensors.insert({"beam_search_diversity_rate",


### PR DESCRIPTION
The bad and stop words can be empty because it's optional.