### PR TITLE
Update huggingface_gptj_ckpt_convert.py

### DIFF
--- a/examples/pytorch/gptj/utils/huggingface_gptj_ckpt_convert.py
+++ b/examples/pytorch/gptj/utils/huggingface_gptj_ckpt_convert.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    ckpt_file = args.ckpt_dir + "pytorch_model.bin"
+    ckpt_file = args.ckpt_dir + "/pytorch_model.bin"
     checkpoint = torch.load(ckpt_file)
     print(f"loading from {ckpt_file}")
     


### PR DESCRIPTION
This script can't find binary file if ckpt-dir isn't finished with '/'. This is an error message: `FileNotFoundError: [Errno 2] No such file or directory: '/workspace/assets/fp32pytorch_model.bin'`.