### PR TITLE
Add tensor_para_size to config file in gpt huggingface ckpt convert script

### DIFF
--- a/examples/pytorch/gpt/utils/huggingface_gpt_convert.py
+++ b/examples/pytorch/gpt/utils/huggingface_gpt_convert.py
@@ -121,6 +121,7 @@ def split_and_convert(args):
         config["gpt"]["start_id"] = str(hf_config["bos_token_id"])
         config["gpt"]["end_id"] = str(hf_config["eos_token_id"])
         config['gpt']['weight_data_type'] = args.weight_data_type
+        config["gpt"]["tensor_para_size"] = str(args.infer_gpu_num)
         with open(saved_dir + "/config.ini", 'w') as configfile:
             config.write(configfile)
     except:


### PR DESCRIPTION
Looks like `tensor_para_size` is missing in huggingface_gpt_convert.py script [here](https://github.com/NVIDIA/FasterTransformer/blob/main/examples/pytorch/gpt/utils/huggingface_gpt_convert.py#L113-L123) as that's being referenced [here](https://github.com/NVIDIA/FasterTransformer/blob/main/examples/pytorch/gpt/multi_gpu_gpt_example.py#L162) and throws an error that the key is missing.