### PR TITLE
[FIX] remove device type

### DIFF
--- a/examples/pytorch/gpt/utils/huggingface_opt_convert.py
+++ b/examples/pytorch/gpt/utils/huggingface_opt_convert.py
@@ -169,7 +169,7 @@ def split_and_convert(args):
     factor = (int)(i_gpu_num / t_gpu_num)
 
     # load position_embedding from rank 0
-    model = AutoModelForCausalLM.from_pretrained(args.in_file, device_map="auto")
+    model = AutoModelForCausalLM.from_pretrained(args.in_file)
 
     capture_dict = None
     if args.act_scale is not None:


### PR DESCRIPTION
For HuggingFace Accelerate:

```
device_map='auto'
```

means to load the model across all visible GPUs. For weight remapping this is unecessary to do given it will make the process run slow. Just load the full model on CPU is sufficient.