### PR TITLE
Fix NCCL version check when nccl.h in non-standard location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,7 +428,7 @@ add_library(transformer-shared SHARED
 if (BUILD_MULTI_GPU)
 target_link_libraries(transformer-shared PUBLIC
   -lmpi
-  -lnccl
+  ${NCCL_LIBRARIES}
 )
 endif()
 

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -148,6 +148,7 @@ if(NCCL_FOUND)  # obtaining NCCL version and some sanity checks
 ")
     try_run(NCCL_VERSION_MATCHED compile_result ${PROJECT_BINARY_DIR} ${file}
           RUN_OUTPUT_VARIABLE NCCL_VERSION_FROM_HEADER
+          CMAKE_FLAGS  "-DINCLUDE_DIRECTORIES=${NCCL_INCLUDE_DIRS}"
           LINK_LIBRARIES ${NCCL_LIBRARIES})
     if (NOT NCCL_VERSION_MATCHED)
       message(FATAL_ERROR "Found NCCL header version and library version do not match! \

--- a/src/fastertransformer/utils/CMakeLists.txt
+++ b/src/fastertransformer/utils/CMakeLists.txt
@@ -64,7 +64,7 @@ add_library(nccl_utils STATIC nccl_utils.cc)
 set_property(TARGET nccl_utils PROPERTY POSITION_INDEPENDENT_CODE  ON)
 set_property(TARGET nccl_utils PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS  ON)
 if (BUILD_MULTI_GPU)
-    target_link_libraries(nccl_utils PUBLIC -lnccl mpi_utils logger)
+    target_link_libraries(nccl_utils PUBLIC ${NCCL_LIBRARIES} mpi_utils logger)
 endif()
 
 add_library(cublasINT8MMWrapper STATIC cublasINT8MMWrapper.cc)


### PR DESCRIPTION
`FindNCCL.cmake` was inspired from PyTorch's `FindNCCL.cmake` from back in 2019 it seems.
But this means that upstream fixes like https://github.com/pytorch/pytorch/pull/40982 haven't been included.

This PR adds the fix from https://github.com/pytorch/pytorch/pull/40982, plus a couple of changes so that NCCL is properly picked if installed in a non-standard location.