### PR TITLE
Fix CUDNN check when cudnn is not in a non-standard location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ if((${CUDA_VERSION_MAJOR} VERSION_GREATER_EQUAL "11" AND ${CUDA_VERSION_MINOR} V
   endif()
 endif()
 
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
+find_package(CUDNN)
+
 option(BUILD_CUTLASS_MOE "Builds CUTLASS kernels supporting MoE GEMM" ON)
 if(BUILD_CUTLASS_MOE)
   message(STATUS "Add DBUILD_CUTLASS_MOE, requires CUTLASS. Increases compilation time")

--- a/cmake/Modules/FindCUDNN.cmake
+++ b/cmake/Modules/FindCUDNN.cmake
@@ -1,0 +1,51 @@
+# taken from https://github.com/pytorch/pytorch/blob/master/cmake/Modules_CUDA_fix/FindCUDNN.cmake
+# Find the CUDNN libraries
+#
+# The following variables are optionally searched for defaults
+#  CUDNN_ROOT: Base directory where CUDNN is found
+#  CUDNN_INCLUDE_DIR: Directory where CUDNN header is searched for
+#  CUDNN_LIBRARY: Directory where CUDNN library is searched for
+#  CUDNN_STATIC: Are we looking for a static library? (default: no)
+#
+# The following are set after configuration is done:
+#  CUDNN_FOUND
+#  CUDNN_INCLUDE_PATH
+#  CUDNN_LIBRARY_PATH
+#
+
+include(FindPackageHandleStandardArgs)
+
+set(CUDNN_ROOT $ENV{CUDNN_ROOT_DIR} CACHE PATH "Folder containing NVIDIA cuDNN")
+if (DEFINED $ENV{CUDNN_ROOT_DIR})
+  message(WARNING "CUDNN_ROOT_DIR is deprecated. Please set CUDNN_ROOT instead.")
+endif()
+list(APPEND CUDNN_ROOT $ENV{CUDNN_ROOT_DIR} ${CUDA_TOOLKIT_ROOT_DIR})
+
+# Compatible layer for CMake <3.12. CUDNN_ROOT will be accounted in for searching paths and libraries for CMake >=3.12.
+list(APPEND CMAKE_PREFIX_PATH ${CUDNN_ROOT})
+
+set(CUDNN_INCLUDE_DIR $ENV{CUDNN_INCLUDE_DIR} CACHE PATH "Folder containing NVIDIA cuDNN header files")
+
+find_path(CUDNN_INCLUDE_PATH cudnn.h
+  HINTS ${CUDNN_INCLUDE_DIR}
+  PATH_SUFFIXES cuda/include cuda include)
+
+option(CUDNN_STATIC "Look for static CUDNN" OFF)
+if (CUDNN_STATIC)
+  set(CUDNN_LIBNAME "libcudnn_static.a")
+else()
+  set(CUDNN_LIBNAME "cudnn")
+endif()
+
+set(CUDNN_LIBRARY $ENV{CUDNN_LIBRARY} CACHE PATH "Path to the cudnn library file (e.g., libcudnn.so)")
+if (CUDNN_LIBRARY MATCHES ".*cudnn_static.a" AND NOT CUDNN_STATIC)
+  message(WARNING "CUDNN_LIBRARY points to a static library (${CUDNN_LIBRARY}) but CUDNN_STATIC is OFF.")
+endif()
+
+find_library(CUDNN_LIBRARY_PATH ${CUDNN_LIBNAME}
+  PATHS ${CUDNN_LIBRARY}
+  PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64)
+
+find_package_handle_standard_args(CUDNN DEFAULT_MSG CUDNN_LIBRARY_PATH CUDNN_INCLUDE_PATH)
+
+mark_as_advanced(CUDNN_ROOT CUDNN_INCLUDE_DIR CUDNN_LIBRARY)

--- a/examples/cpp/swin/CMakeLists.txt
+++ b/examples/cpp/swin/CMakeLists.txt
@@ -18,4 +18,4 @@ set(swin_transformer_nv_files
 )
 add_executable(swin_example ${swin_transformer_nv_files})
 target_link_libraries(swin_example PUBLIC trt_fused_multi_head_attention Swin 
-  cublasMMWrapper memory_utils -lcublas -lcublasLt -lcudart -lcudnn tensor)
+  cublasMMWrapper memory_utils -lcublas -lcublasLt -lcudart "${CUDNN_LIBRARY_PATH}" tensor)

--- a/examples/cpp/swin_int8/CMakeLists.txt
+++ b/examples/cpp/swin_int8/CMakeLists.txt
@@ -15,4 +15,4 @@ cmake_minimum_required(VERSION 3.8)
 
 add_executable(swin_int8_example swin_int8_example.cc)
 target_link_libraries(swin_int8_example PUBLIC trt_fused_multi_head_attention SwinINT8 cublasAlgoMap 
-    cublasINT8MMWrapper quantize_weight memory_utils -lcublasLt -lcublas -lcudart -lcudnn)
+  cublasINT8MMWrapper quantize_weight memory_utils -lcublasLt -lcublas -lcudart "${CUDNN_LIBRARY_PATH}")

--- a/examples/cpp/vit/CMakeLists.txt
+++ b/examples/cpp/vit/CMakeLists.txt
@@ -15,4 +15,4 @@ cmake_minimum_required(VERSION 3.8)
 
 add_executable(vit_example vit_example.cc)
 target_link_libraries(vit_example PUBLIC ViT trt_fused_multi_head_attention vit_kernels
-  cublasMMWrapper -lcublas -lcublasLt -lcudart -lcudnn -lm nvtx_utils)
+  cublasMMWrapper -lcublas -lcublasLt -lcudart "${CUDNN_LIBRARY_PATH}" -lm nvtx_utils)

--- a/examples/cpp/vit_int8/CMakeLists.txt
+++ b/examples/cpp/vit_int8/CMakeLists.txt
@@ -15,4 +15,4 @@ cmake_minimum_required(VERSION 3.8)
 
 add_executable(vit_int8_example vit_int8_example.cc)
 target_link_libraries(vit_int8_example PUBLIC ViTINT8 trt_fused_multi_head_attention vit_kernels
-  cublasMMWrapper nvtx_utils -lcublas -lcublasLt -lcudart -lcudnn -lm)
+  cublasMMWrapper nvtx_utils -lcublas -lcublasLt -lcudart "${CUDNN_LIBRARY_PATH}" -lm)

--- a/examples/cpp/wenet/CMakeLists.txt
+++ b/examples/cpp/wenet/CMakeLists.txt
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 add_executable(wenet_encoder_example wenet_encoder_example.cc)
-target_link_libraries(wenet_encoder_example PUBLIC -lcublas -lcublasLt -lcudart -lcudnn WenetEncoder)
+target_link_libraries(wenet_encoder_example PUBLIC -lcublas -lcublasLt -lcudart "${CUDNN_LIBRARY_PATH}" WenetEncoder)
 if (SPARSITY_SUPPORT)
 target_link_libraries(wenet_encoder_example PUBLIC -lcusparse -lcusparseLt)
 endif()
 
 add_executable(wenet_decoder_example wenet_decoder_example.cc)
-target_link_libraries(wenet_decoder_example PUBLIC -lcublas -lcublasLt -lcudart -lcudnn WenetDecoder)
+target_link_libraries(wenet_decoder_example PUBLIC -lcublas -lcublasLt -lcudart "${CUDNN_LIBRARY_PATH}" WenetDecoder)
 if(SPARSITY_SUPPORT)
     target_link_libraries(wenet_decoder_example PUBLIC -lcublas -lcusparse -lcusparseLt)
 endif()

--- a/src/fastertransformer/models/wenet/CMakeLists.txt
+++ b/src/fastertransformer/models/wenet/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(WenetEncoder STATIC WenetEncoder.cc
                                 )
 set_property(TARGET WenetEncoder PROPERTY POSITION_INDEPENDENT_CODE  ON)
 set_property(TARGET WenetEncoder PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS  ON)
-target_link_libraries(WenetEncoder PUBLIC -lcudart -lcudnn
+target_link_libraries(WenetEncoder PUBLIC -lcudart "${CUDNN_LIBRARY_PATH}"
     bert_preprocess_kernels
     cublasMMWrapper
     FfnLayer

--- a/src/fastertransformer/th_op/swin/CMakeLists.txt
+++ b/src/fastertransformer/th_op/swin/CMakeLists.txt
@@ -30,5 +30,5 @@ if(BUILD_PYT)
   target_link_libraries(${LIB_NAME} "${TORCH_LIBRARIES}" Swin SwinINT8 
     cublasINT8MMWrapper cublasAlgoMap trt_fused_multi_head_attention 
     gen_relative_pos_bias quantize_weight transform_mask_kernels
-    -lcudnn -lcublas -lcudart)
+    "${CUDNN_LIBRARY_PATH}" -lcublas -lcudart)
 endif()

--- a/src/fastertransformer/th_op/vit/CMakeLists.txt
+++ b/src/fastertransformer/th_op/vit/CMakeLists.txt
@@ -27,5 +27,5 @@ if(BUILD_PYT)
   set_property(TARGET ${LIB_NAME} PROPERTY POSITION_INDEPENDENT_CODE  ON)
   set_target_properties(${LIB_NAME} PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
   target_link_libraries(${LIB_NAME} ViT ViTINT8 quantize_weight cublasMMWrapper trt_fused_multi_head_attention 
-    -lcudnn -lcublas -lcudart "${TORCH_LIBRARIES}")
+    "${CUDNN_LIBRARY_PATH}" -lcublas -lcudart "${TORCH_LIBRARIES}")
 endif()


### PR DESCRIPTION
This PRs adds support for cudnn to live in a non-standard location.
It takes [`FindCUDNN.cmake` from PyTorch](https://github.com/pytorch/pytorch/blob/master/cmake/Modules_CUDA_fix/FindCUDNN.cmake) and replaces the `lcudnn` arguments with what `FindCUDNN` retrieves.

This PR, together with https://github.com/NVIDIA/FasterTransformer/pull/430, enabled me to compile FasterTransformer outside of its provided docker image.