### PR TITLE
Add Layernorm option for Wenet trt

### DIFF
--- a/src/fastertransformer/models/wenet/WenetEncoder.cc
+++ b/src/fastertransformer/models/wenet/WenetEncoder.cc
@@ -213,8 +213,8 @@ void WenetEncoder<T>::allocateBuffer(
         inter_conv2_output_buf_, sizeof(T) * batch_size * d_model_ * seq_len2 * feature_size2, false);
     inter_fc_input_buf_ = (T*)allocator_->reMalloc(
         inter_fc_input_buf_, sizeof(T) * batch_size * seq_len2 * d_model_ * feature_size2, false);
-    // Current workspace used for CuDNN Convolution is 1 << 27
-    conv_workspace_ = (T*)allocator_->reMalloc(conv_workspace_, 1 << 27, false);
+    // Current workspace used for CuDNN Convolution is 1 << 29
+    conv_workspace_ = (T*)allocator_->reMalloc(conv_workspace_, 1 << 29, false);
     // Position Embed
 
     input_hidden_state_ =

--- a/src/fastertransformer/tensorrt_plugin/wenet/DecoderPlugin.cc
+++ b/src/fastertransformer/tensorrt_plugin/wenet/DecoderPlugin.cc
@@ -67,8 +67,7 @@ void WenetDecoderPlugin::CreateFT()
 #endif
 
     // Wenet DecoderWeight
-    std::string weightFilePath = "/weight/dec/";
-    // std::string weightFilePath = m_.weightFilePath;
+    std::string weightFilePath = m_.weightFilePath;
     FT_LOG_WARNING("The default weight file path is %s. Change it accordingly, otherwise model will fail to load! \n",
                    weightFilePath.c_str());
     if (m_.useFP16) {

--- a/src/fastertransformer/tensorrt_plugin/wenet/EncoderPlugin.cc
+++ b/src/fastertransformer/tensorrt_plugin/wenet/EncoderPlugin.cc
@@ -44,23 +44,23 @@ WenetEncoderPlugin::WenetEncoderPlugin(const std::string& name,
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
     WHERE_AM_I();
-    m_.max_batch_size          = max_batch_size;
-    m_.max_seq_len             = max_seq_len;
-    m_.head_num                = head_num;
-    m_.size_per_head           = size_per_head;
-    m_.feature_size            = feature_size;
-    m_.max_len                 = max_len;
-    m_.inter_size              = inter_size;
-    m_.d_model                 = d_model;
-    m_.num_layer               = num_layer;
-    m_.vocab_size              = vocab_size;
-    m_.conv_module_kernel_size = conv_module_kernel_size;
-    m_.sm                      = sm;
-    m_.q_scaling               = q_scaling;
+    m_.max_batch_size               = max_batch_size;
+    m_.max_seq_len                  = max_seq_len;
+    m_.head_num                     = head_num;
+    m_.size_per_head                = size_per_head;
+    m_.feature_size                 = feature_size;
+    m_.max_len                      = max_len;
+    m_.inter_size                   = inter_size;
+    m_.d_model                      = d_model;
+    m_.num_layer                    = num_layer;
+    m_.vocab_size                   = vocab_size;
+    m_.conv_module_kernel_size      = conv_module_kernel_size;
+    m_.sm                           = sm;
+    m_.q_scaling                    = q_scaling;
     m_.use_layernorm_in_conv_module = (bool)use_layernorm_in_conv_module;
-    m_.useFP16                 = (bool)useFP16;
-    m_.batch_size              = m_.max_batch_size;
-    m_.seq_len                 = m_.max_seq_len;
+    m_.useFP16                      = (bool)useFP16;
+    m_.batch_size                   = m_.max_batch_size;
+    m_.seq_len                      = m_.max_seq_len;
     strcpy(m_.weightFilePath, weightFilePath.c_str());
 
     CreateFT();
@@ -76,8 +76,7 @@ void WenetEncoderPlugin::CreateFT()
     cudnnCreate(&cudnn_handle_);
 
     // Wenet EncoderWeight
-    std::string weightFilePath = "/weight/enc/";
-    // std::string weightFilePath = m_.weightFilePath;
+    std::string weightFilePath = m_.weightFilePath;
     FT_LOG_WARNING("The default weight file path is %s. Change it accordingly, otherwise model will fail to load! \n",
                    weightFilePath.c_str());
     if (m_.useFP16) {
@@ -508,22 +507,22 @@ IPluginV2* WenetEncoderPluginCreator::createPlugin(const char* name, const Plugi
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
     WHERE_AM_I();
-    int         max_batch_size          = 128;
-    int         max_seq_len             = 384;
-    int         head_num                = 8;
-    int         size_per_head           = 32;
-    int         feature_size            = 80;
-    int         max_len                 = 5000;
-    int         d_model                 = head_num * size_per_head;
-    int         inter_size              = d_model * 4;
-    int         num_layer               = 12;
-    int         vocab_size              = 4233;
-    int         conv_module_kernel_size = 15;
-    int         sm                      = -1;
-    float       q_scaling               = 1.0f / (sqrt(size_per_head) * 1.0f);
-    std::string weightFilePath          = "";
+    int         max_batch_size               = 128;
+    int         max_seq_len                  = 384;
+    int         head_num                     = 8;
+    int         size_per_head                = 32;
+    int         feature_size                 = 80;
+    int         max_len                      = 5000;
+    int         d_model                      = head_num * size_per_head;
+    int         inter_size                   = d_model * 4;
+    int         num_layer                    = 12;
+    int         vocab_size                   = 4233;
+    int         conv_module_kernel_size      = 15;
+    int         sm                           = -1;
+    float       q_scaling                    = 1.0f / (sqrt(size_per_head) * 1.0f);
+    std::string weightFilePath               = "";
     int         use_layernorm_in_conv_module = 0;
-    int         useFP16                 = 0;
+    int         useFP16                      = 0;
 
     struct cudaDeviceProp prop;
     cudaGetDeviceProperties(&prop, 0);

--- a/src/fastertransformer/tensorrt_plugin/wenet/EncoderPlugin.cc
+++ b/src/fastertransformer/tensorrt_plugin/wenet/EncoderPlugin.cc
@@ -90,7 +90,8 @@ void WenetEncoderPlugin::CreateFT()
                                                                 m_.conv_module_kernel_size,
                                                                 m_.feature_size,
                                                                 m_.max_len,
-                                                                m_.num_layer);
+                                                                m_.num_layer,
+                                                                m_.use_layernorm_in_conv_module);
         pWenetEncoderWeightHalf_->loadModel(weightFilePath);
     }
     else {
@@ -103,7 +104,8 @@ void WenetEncoderPlugin::CreateFT()
                                                                   m_.conv_module_kernel_size,
                                                                   m_.feature_size,
                                                                   m_.max_len,
-                                                                  m_.num_layer);
+                                                                  m_.num_layer,
+                                                                  m_.use_layernorm_in_conv_module);
         pWenetEncoderWeightFloat_->loadModel(weightFilePath);
     }
 

--- a/src/fastertransformer/tensorrt_plugin/wenet/EncoderPlugin.h
+++ b/src/fastertransformer/tensorrt_plugin/wenet/EncoderPlugin.h
@@ -45,7 +45,7 @@
     printf("\tnum_layer=%ld\n", m_.num_layer);                                                                         \
     printf("\tsm=%d\n", m_.sm);                                                                                        \
     printf("\tq_scaling=%f\n", m_.q_scaling);
-    printf("\tuse_layernorm_in_cnn_module=%d\n", m_.use_layernorm_in_cnn_module);                                                                           \
+    printf("\tuse_layernorm_in_cnn_module=%d\n", m_.use_layernorm_in_cnn_module);                                      \
     printf("\tuseFP16=%d\n", m_.useFP16);                                                                              \
     printf("\tweightFilePath=%s\n", m_.weightFilePath);                                                                \
     printf("\tvocab_size=%ld\n", m_.vocab_size);                                                                       \

--- a/src/fastertransformer/tensorrt_plugin/wenet/EncoderPlugin.h
+++ b/src/fastertransformer/tensorrt_plugin/wenet/EncoderPlugin.h
@@ -44,7 +44,8 @@
     printf("\td_model=%ld\n", m_.d_model);                                                                             \
     printf("\tnum_layer=%ld\n", m_.num_layer);                                                                         \
     printf("\tsm=%d\n", m_.sm);                                                                                        \
-    printf("\tq_scaling=%f\n", m_.q_scaling);                                                                          \
+    printf("\tq_scaling=%f\n", m_.q_scaling);
+    printf("\tuse_layernorm_in_cnn_module=%d\n", m_.use_layernorm_in_cnn_module);                                                                           \
     printf("\tuseFP16=%d\n", m_.useFP16);                                                                              \
     printf("\tweightFilePath=%s\n", m_.weightFilePath);                                                                \
     printf("\tvocab_size=%ld\n", m_.vocab_size);                                                                       \
@@ -111,6 +112,7 @@ private:
         size_t conv_module_kernel_size = 15;
         int    sm                      = -1;  // assign later
         float  q_scaling               = 1.0f / (1.0f * sqrt(size_per_head));
+        bool   use_layernorm_in_conv_module = false;
         bool   useFP16                 = false;
         // internal parameter
         bool                              is_remove_padding            = false;
@@ -144,6 +146,7 @@ public:
                        int                sm,
                        float              q_scaling,
                        const std::string& weightFilePath,
+                       int                use_layernorm_in_conv_module,
                        int                useFP16);
     WenetEncoderPlugin(const std::string& name, const void* buffer, size_t length);
     ~WenetEncoderPlugin();

--- a/src/fastertransformer/tensorrt_plugin/wenet/EncoderPlugin.h
+++ b/src/fastertransformer/tensorrt_plugin/wenet/EncoderPlugin.h
@@ -44,7 +44,7 @@
     printf("\td_model=%ld\n", m_.d_model);                                                                             \
     printf("\tnum_layer=%ld\n", m_.num_layer);                                                                         \
     printf("\tsm=%d\n", m_.sm);                                                                                        \
-    printf("\tq_scaling=%f\n", m_.q_scaling);
+    printf("\tq_scaling=%f\n", m_.q_scaling);                                                                          \
     printf("\tuse_layernorm_in_cnn_module=%d\n", m_.use_layernorm_in_cnn_module);                                      \
     printf("\tuseFP16=%d\n", m_.useFP16);                                                                              \
     printf("\tweightFilePath=%s\n", m_.weightFilePath);                                                                \

--- a/src/fastertransformer/tensorrt_plugin/wenet/EncoderPlugin.h
+++ b/src/fastertransformer/tensorrt_plugin/wenet/EncoderPlugin.h
@@ -99,21 +99,21 @@ private:
     WenetEncoder<float>*            pWenetEncoderFloat_       = nullptr;
     struct {
         // constructor parameter
-        size_t max_batch_size          = 16;
-        size_t max_seq_len             = 256;
-        size_t head_num                = 8;
-        size_t size_per_head           = 32;
-        size_t feature_size            = 80;
-        size_t max_len                 = 5000;
-        size_t inter_size              = head_num * size_per_head * 4;
-        size_t d_model                 = head_num * size_per_head;
-        size_t num_layer               = 12;
-        size_t vocab_size              = 4233;
-        size_t conv_module_kernel_size = 15;
-        int    sm                      = -1;  // assign later
-        float  q_scaling               = 1.0f / (1.0f * sqrt(size_per_head));
+        size_t max_batch_size               = 16;
+        size_t max_seq_len                  = 256;
+        size_t head_num                     = 8;
+        size_t size_per_head                = 32;
+        size_t feature_size                 = 80;
+        size_t max_len                      = 5000;
+        size_t inter_size                   = head_num * size_per_head * 4;
+        size_t d_model                      = head_num * size_per_head;
+        size_t num_layer                    = 12;
+        size_t vocab_size                   = 4233;
+        size_t conv_module_kernel_size      = 15;
+        int    sm                           = -1;  // assign later
+        float  q_scaling                    = 1.0f / (1.0f * sqrt(size_per_head));
         bool   use_layernorm_in_conv_module = false;
-        bool   useFP16                 = false;
+        bool   useFP16                      = false;
         // internal parameter
         bool                              is_remove_padding            = false;
         bool                              is_free_buffer_after_forward = false;

--- a/src/fastertransformer/utils/wenet_conv2d.h
+++ b/src/fastertransformer/utils/wenet_conv2d.h
@@ -156,8 +156,8 @@ void conv2d(T*             output,
                                                        &ws_size));
     FT_LOG_DEBUG("Convolution algorithm: %d with workspace size: %d \n", convolution_algorithm_, ws_size);
     FT_CHECK_WITH_INFO(
-        ws_size <= (1 << 27),
-        "Current workspace used for CuDNN Convolution is fixed as 1 << 27, please increase it in WenetEncoder::allocateBuffer!");
+        ws_size <= (1 << 29),
+        "Current workspace used for CuDNN Convolution is fixed as 1 << 29, please increase it in WenetEncoder::allocateBuffer!");
     // void *ws_data;
     // if (ws_size > 0) {
     //     check_cuda_error(cudaMalloc(&ws_data, ws_size));


### PR DESCRIPTION
1. remove hard-coding path, since trt 8.5.1.7 has fixed previous issue.
2. add layernorm option for different wenet configuration
3. increase pre-allocate conv space from 1<<27 to 1<<29, which is necessary for concurrency more than 100.