### PR TITLE
Fix Japanese Hugging face GPT conversion

### DIFF
--- a/examples/pytorch/gpt/utils/huggingface_jp_gpt_convert.py
+++ b/examples/pytorch/gpt/utils/huggingface_jp_gpt_convert.py
@@ -121,6 +121,7 @@ def split_and_convert(args):
     config["gpt"]["start_id"] = str(hf_config["bos_token_id"])
     config["gpt"]["end_id"] = str(hf_config["eos_token_id"])
     config['gpt']['weight_data_type'] = args.weight_data_type
+    config["gpt"]["tensor_para_size"] = str(args.infer_gpu_num)
     with open(saved_dir + "/config.ini", 'w') as configfile:
         config.write(configfile)
     

--- a/examples/pytorch/gpt/utils/huggingface_jp_gpt_convert.py
+++ b/examples/pytorch/gpt/utils/huggingface_jp_gpt_convert.py
@@ -101,6 +101,8 @@ def split_and_convert(args):
     model = GPT2Model.from_pretrained(args.in_file).to(torch.device('cuda:0'))
 
     hf_config = vars(model.config)
+    config = configparser.ConfigParser()
+    config["gpt"] = {}
 
     config["gpt"]["model_name"] = "gpt" if hf_config["_name_or_path"] == '' else hf_config["_name_or_path"]
     config["gpt"]["head_num"] = str(hf_config["n_head"])
@@ -113,7 +115,7 @@ def split_and_convert(args):
     config["gpt"]["start_id"] = str(hf_config["bos_token_id"])
     config["gpt"]["end_id"] = str(hf_config["eos_token_id"])
     config['gpt']['weight_data_type'] = args.weight_data_type
-    with open(output_dir + "/config.ini", 'w') as configfile:
+    with open(saved_dir + "/config.ini", 'w') as configfile:
         config.write(configfile)
     
     np_weight_data_type = get_weight_data_type(args.weight_data_type)

--- a/examples/pytorch/gpt/utils/huggingface_jp_gpt_convert.py
+++ b/examples/pytorch/gpt/utils/huggingface_jp_gpt_convert.py
@@ -104,7 +104,8 @@ def split_and_convert(args):
 
     # load position_embedding from rank 0 
     # model = torch.load(ckpt_name)
-    model = GPT2LMHeadModel.from_pretrained(args.in_file).to(torch.device('cuda:0'))
+    torch_device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    model = GPT2LMHeadModel.from_pretrained(args.in_file).to(torch_device)
 
     hf_config = vars(model.config)
     config = configparser.ConfigParser()


### PR DESCRIPTION
Fixes #459 
1. Define missing variables, correct variable names.
2. Use GPT2LMHeadModel and state_dict() instead of GPT2Model and named_parameters() to collect model weights.
3. Dynamically select torch device instead of the hardocded GPU.
4. Add `tensor_para_size` to config.
5. Add docstring to recommend usage of `huggingface_gpt_model.py` instead of this file.