### PR TITLE
fix several CMakeLists.txt files to support building corresponding ta…

### DIFF
--- a/src/fastertransformer/layers/attention_layers_int8/CMakeLists.txt
+++ b/src/fastertransformer/layers/attention_layers_int8/CMakeLists.txt
@@ -32,3 +32,4 @@ set_property(TARGET WindowAttentionINT8 PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS  ON
 target_link_libraries(WindowAttentionINT8 PUBLIC -lcublasLt -lcublas -lcudart cublasINT8MMWrapper reverse_roll_kernels 
     trt_fused_multi_head_attention layout_transformer_int8_kernels transpose_int8_kernels unfused_attention_int8_kernels
     layernorm_int8_kernels softmax_int8_kernels layernorm_kernels transform_mask_kernels normalize_kernels)
+target_include_directories(WindowAttentionINT8 PUBLIC ${CUDNN_INCLUDE_PATH})

--- a/src/fastertransformer/models/swin/CMakeLists.txt
+++ b/src/fastertransformer/models/swin/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(Swin STATIC Swin.cc)
 set_property(TARGET Swin PROPERTY POSITION_INDEPENDENT_CODE  ON)
 set_property(TARGET Swin PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS  ON)
 target_link_libraries(Swin PUBLIC -lcudart SwinBasicLayer memory_utils cuda_utils logger)
+target_include_directories(Swin PUBLIC ${CUDNN_INCLUDE_PATH})
 
 add_executable(swin_gemm swin_gemm.cc)
 target_link_libraries(swin_gemm PUBLIC -lcublas -lcublasLt -lcudart swin_igemm_func

--- a/src/fastertransformer/models/vit/CMakeLists.txt
+++ b/src/fastertransformer/models/vit/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(ViT PUBLIC -lcudart -lcublasLt -lcublas cublasMMWrapper
                       UnfusedAttentionLayer FusedAttentionLayer FfnLayer layernorm_kernels
                       add_residual_kernels activation_kernels vit_kernels bert_preprocess_kernels
                       tensor cuda_utils logger)
+target_include_directories(ViT PUBLIC ${CUDNN_INCLUDE_PATH})
 
 add_executable(vit_gemm vit_gemm.cc)
 target_link_libraries(vit_gemm PUBLIC -lcublas -lcublasLt -lcudart encoder_gemm_func encoder_igemm_func

--- a/src/fastertransformer/models/vit_int8/CMakeLists.txt
+++ b/src/fastertransformer/models/vit_int8/CMakeLists.txt
@@ -21,3 +21,4 @@ target_link_libraries(ViTINT8 PUBLIC -lcudart -lcublasLt -lcublas cublasINT8MMWr
                       UnfusedAttentionLayerINT8 FusedAttentionLayerINT8 FfnLayerINT8 layernorm_kernels
                       layernorm_int8_kernels add_residual_kernels activation_kernels layout_transformer_int8_kernels
                       vit_kernels bert_preprocess_kernels tensor cuda_utils logger)
+target_include_directories(ViTINT8 PUBLIC ${CUDNN_INCLUDE_PATH})

--- a/src/fastertransformer/models/wenet/CMakeLists.txt
+++ b/src/fastertransformer/models/wenet/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(WenetEncoder PUBLIC -lcudart "${CUDNN_LIBRARY_PATH}"
     layernorm_kernels
     add_residual_kernels
     )
+target_include_directories(WenetEncoder PUBLIC ${CUDNN_INCLUDE_PATH})
 
 add_executable(wenet_gemm wenet_gemm.cc)
 target_link_libraries(wenet_gemm PUBLIC -lcublas -lcublasLt -lcudart encoder_gemm_func memory_utils)


### PR DESCRIPTION
## Background 

My machine have been installed  `cudnn` under the non-standard path `/usr/local/cudnn-linux-x86_64-8.4.1.50_cuda11.6-archive`, and the directory tree under this path looks like:

```bash
/usr/local/cudnn-linux-x86_64-8.4.1.50_cuda11.6-archive/
├── include
├── lib
└── LICENSE
```

## Problem 

When I ran `cmake` with following options: 

```bash
cmake .. -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-11.6 \
    -DCUDNN_LIBRARY_PATH=/usr/local/cudnn-linux-x86_64-8.4.1.50_cuda11.6-archive/lib \
    -DCUDNN_INCLUDE_PATH=/usr/local/cudnn-linux-x86_64-8.4.1.50_cuda11.6-archive/include \
    -DCMAKE_CUDA_ARCHITECTURES=80-real 
```

Some target libraries such as `swin_gemm`, `vit_gemm`, `WenetEncoder` and `ViTINT8` still failed to find `cudnn.h`. The error during building looks like: 

```bash
[ 75%] Building CXX object src/fastertransformer/models/vit_int8/CMakeFiles/ViTINT8.dir/ViTINT8.cc.o
In file included from /data/huangzhuobin/projects/oneflow_features/FasterTransformer/src/fastertransformer/models/vit_int8/ViTINT8.h:26,
                 from /data/huangzhuobin/projects/oneflow_features/FasterTransformer/src/fastertransformer/models/vit_int8/[ViTINT8.cc:17](http://vitint8.cc:17/):
/data/huangzhuobin/projects/oneflow_features/FasterTransformer/src/fastertransformer/utils/conv2d.h:24:10: fatal error: cudnn.h: No such file or directory
   24 | #include <cudnn.h>
      |          ^~~~~~~~~
compilation terminated.
make[2]: *** [src/fastertransformer/models/vit_int8/CMakeFiles/ViTINT8.dir/build.make:76: src/fastertransformer/models/vit_int8/CMakeFiles/ViTINT8.dir/ViTINT8.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:6880: src/fastertransformer/models/vit_int8/CMakeFiles/ViTINT8.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

## Fix

This patch specifies the CUDNN include path for these target libraries via the `CUDNN_INCLUDE_PATH` which passed within `cmake` option