### PR TITLE
Fix torch multiprocessing error in gptneox conversion script

### DIFF
--- a/examples/pytorch/gptneox/gptneox_example.py
+++ b/examples/pytorch/gptneox/gptneox_example.py
@@ -109,7 +109,7 @@ def main():
     if tensor_para_size * pipeline_para_size > 1:
         dist.init_process_group(backend=dist.Backend.MPI)
     rank = dist.get_rank() if dist.is_initialized() else 0
-    device_count = dist.get_world_size() if dist.is_initialized() else 1
+    device_count = torch.cuda.device_count() if dist.is_initialized() else 1
     device = rank % device_count
     torch.cuda.set_device(device)
     device = torch.cuda.current_device()


### PR DESCRIPTION
Fixes:
1. `Context has already been set` error from torch multiprocessing similar to https://github.com/NVIDIA/FasterTransformer/pull/443
2. I think the `device_count` is incorrectly set in the example script.