### PR TITLE
Update huggingface_gptj_ckpt_convert.py

### DIFF
--- a/examples/pytorch/gptj/utils/huggingface_gptj_ckpt_convert.py
+++ b/examples/pytorch/gptj/utils/huggingface_gptj_ckpt_convert.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
         "--output-dir", help="Folder where binary files are stored", default="gpt-j-6B/c-models/"
     )
     parser.add_argument(
-        "--ckpt-dir", help="File of GPT-J huggingface checkpoint", default="gpt-j-6B/"
+        "--ckpt-dir", help="File of GPT-J huggingface checkpoint", default="gpt-j-6B"
     )
     parser.add_argument(
         "--n-inference-gpus", help="Number of GPUs used for inference runtime", default=1, type=int


### PR DESCRIPTION
Remove trailling slash from default value of --ckpt-dir in huggingface_gptj_ckpt_convert.py preventing the command being run without arguments ( it tries to reference the model with a // double slash )