### PR TITLE
fix multi-gpu build

### DIFF
--- a/src/fastertransformer/utils/CMakeLists.txt
+++ b/src/fastertransformer/utils/CMakeLists.txt
@@ -57,7 +57,7 @@ add_library(mpi_utils STATIC mpi_utils.cc)
 set_property(TARGET mpi_utils PROPERTY POSITION_INDEPENDENT_CODE  ON)
 set_property(TARGET mpi_utils PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS  ON)
 if (BUILD_MULTI_GPU)
-    target_link_libraries(mpi_utils PUBLIC -lmpi logger)
+    target_link_libraries(mpi_utils PUBLIC -lmpi -lmpi_cxx logger)
 endif()
 
 add_library(nccl_utils STATIC nccl_utils.cc)


### PR DESCRIPTION
Multi-gpu build with the following command fails on Ubuntu 20.04.5. Fix it by linking mpi_cxx library. 

`cmake -DSM=80 -DCMAKE_BUILD_TYPE=Release -DBUILD_PYT=ON -DBUILD_MULTI_GPU=ON ..; make -j`

`/usr/bin/ld: CMakeFiles/bert_triton_example.dir/bert_triton_example.cc.o: in function `MPI::Op::Init(void (*)(void const*, void*, int, MPI::Datatype const&), bool)':
bert_triton_example.cc:(.text._ZN3MPI2Op4InitEPFvPKvPviRKNS_8DatatypeEEb[_ZN3MPI2Op4InitEPFvPKvPviRKNS_8DatatypeEEb]+0x1d): undefined reference to `ompi_mpi_cxx_op_intercept'
/usr/bin/ld: CMakeFiles/bert_triton_example.dir/bert_triton_example.cc.o: in function `MPI::Intracomm::Clone() const':
bert_triton_example.cc:(.text._ZNK3MPI9Intracomm5CloneEv[_ZNK3MPI9Intracomm5CloneEv]+0x40): undefined reference to `MPI::Comm::Comm()'
/usr/bin/ld: CMakeFiles/bert_triton_example.dir/bert_triton_example.cc.o: in function `MPI::Graphcomm::Clone() const':
bert_triton_example.cc:(.text._ZNK3MPI9Graphcomm5CloneEv[_ZNK3MPI9Graphcomm5CloneEv]+0x3b): undefined reference to `MPI::Comm::Comm()'
/usr/bin/ld: CMakeFiles/bert_triton_example.dir/bert_triton_example.cc.o: in function `MPI::Cartcomm::Sub(bool const*) const':
bert_triton_example.cc:(.text._ZNK3MPI8Cartcomm3SubEPKb[_ZNK3MPI8Cartcomm3SubEPKb]+0xa1): undefined reference to `MPI::Comm::Comm()'
/usr/bin/ld: CMakeFiles/bert_triton_example.dir/bert_triton_example.cc.o: in function `MPI::Intracomm::Create_graph(int, int const*, int const*, bool) const':
bert_triton_example.cc:(.text._ZNK3MPI9Intracomm12Create_graphEiPKiS2_b[_ZNK3MPI9Intracomm12Create_graphEiPKiS2_b]+0x42): undefined reference to `MPI::Comm::Comm()'
/usr/bin/ld: CMakeFiles/bert_triton_example.dir/bert_triton_example.cc.o: in function `MPI::Cartcomm::Clone() const':
bert_triton_example.cc:(.text._ZNK3MPI8Cartcomm5CloneEv[_ZNK3MPI8Cartcomm5CloneEv]+0x3b): undefined reference to `MPI::Comm::Comm()'
/usr/bin/ld: CMakeFiles/bert_triton_example.dir/bert_triton_example.cc.o:bert_triton_example.cc:(.text._ZNK3MPI9Intracomm11Create_cartEiPKiPKbb[_ZNK3MPI9Intracomm11Create_cartEiPKiPKbb]+0xaa): more undefined references to `MPI::Comm::Comm()' follow
/usr/bin/ld: CMakeFiles/bert_triton_example.dir/bert_triton_example.cc.o:(.data.rel.ro._ZTVN3MPI8DatatypeE[_ZTVN3MPI8DatatypeE]+0x78): undefined reference to `MPI::Datatype::Free()'
/usr/bin/ld: CMakeFiles/bert_triton_example.dir/bert_triton_example.cc.o:(.data.rel.ro._ZTVN3MPI3WinE[_ZTVN3MPI3WinE]+0x48): undefined reference to `MPI::Win::Free()'`