### PR TITLE
Fix for docker image build

### DIFF
--- a/docker/Dockerfile.torch
+++ b/docker/Dockerfile.torch
@@ -45,7 +45,7 @@ RUN git submodule update --init --recursive && \
 #     pip install git+https://github.com/NVIDIA/apex --global-option="--cpp_ext" --global-option="--cuda_ext" --global-option="--fast_layer_norm" && \
 #     pip install 3rdparty/NeMo[nlp]
 RUN pip install --upgrade --no-cache-dir pip \
- && pip install --no-cache-dir 3rdparty/NeMo[nlp]
+ && pip install --no-cache-dir 3rdparty/NeMo[nlp] --ignore-installed
 
 ENV NCCL_LAUNCH_MODE=GROUP
 ARG SM=80

--- a/docker/Dockerfile.torch
+++ b/docker/Dockerfile.torch
@@ -44,8 +44,9 @@ RUN git submodule update --init --recursive && \
 # RUN pip uninstall -y apex && \
 #     pip install git+https://github.com/NVIDIA/apex --global-option="--cpp_ext" --global-option="--cuda_ext" --global-option="--fast_layer_norm" && \
 #     pip install 3rdparty/NeMo[nlp]
+RUN conda update --all
 RUN pip install --upgrade --no-cache-dir pip \
- && pip install --no-cache-dir 3rdparty/NeMo[nlp] --ignore-installed
+ && pip install --no-cache-dir 3rdparty/NeMo[nlp]
 
 ENV NCCL_LAUNCH_MODE=GROUP
 ARG SM=80


### PR DESCRIPTION
This is a workaround for #629. 

Not sure if there is a better way to go about it, but this seems to works for me, so thought I'd add it as a suggestion at least.

**EDIT**: With `--ignore-installed` the image builds, but I had some problems further down the line. Running `conda update --all` before pip install seems to work better. 