### PR TITLE
Huggingface gptj convert script supports sharded checkpoint

### DIFF
--- a/examples/pytorch/gptj/utils/huggingface_gptj_ckpt_convert.py
+++ b/examples/pytorch/gptj/utils/huggingface_gptj_ckpt_convert.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import torch
 import configparser
-from transformers import PretrainedConfig
+from transformers import PretrainedConfig, GPTJForCausalLM
 
 torch.set_printoptions(linewidth=130, sci_mode=False)
 np.set_printoptions(linewidth=130, suppress=True)
@@ -111,9 +111,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    ckpt_file = args.ckpt_dir + "/pytorch_model.bin"
-    checkpoint = torch.load(ckpt_file)
-    print(f"loading from {ckpt_file}")
+    checkpoint = GPTJForCausalLM.from_pretrained(args.ckpt_dir)
+    checkpoint = checkpoint.state_dict()
+    print(f"loading from {args.ckpt_dir}")
 
     out_path = args.output_dir
     output_dir = out_path + f"/{args.n_inference_gpus}-gpu/"


### PR DESCRIPTION
https://huggingface.co/docs/transformers/big_models

Huggingface saves models as sharded for large models,
but previous convert code loaded directly from pytorch_model.bin.
Changed it to load using 'from_pretrained' function, in order to support sharded checkpoints.