### PR TITLE
remove mpi_cxx from multi-gpu build

### DIFF
--- a/src/fastertransformer/utils/CMakeLists.txt
+++ b/src/fastertransformer/utils/CMakeLists.txt
@@ -57,7 +57,7 @@ add_library(mpi_utils STATIC mpi_utils.cc)
 set_property(TARGET mpi_utils PROPERTY POSITION_INDEPENDENT_CODE  ON)
 set_property(TARGET mpi_utils PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS  ON)
 if (BUILD_MULTI_GPU)
-    target_link_libraries(mpi_utils PUBLIC -lmpi -lmpi_cxx logger)
+    target_link_libraries(mpi_utils PUBLIC -lmpi logger)
 endif()
 
 add_library(nccl_utils STATIC nccl_utils.cc)


### PR DESCRIPTION
As noted in [this comment](https://github.com/NVIDIA/FasterTransformer/pull/660/files#r1242623528) linking against mpi_cxx breaks https://github.com/triton-inference-server/fastertransformer_backend since it builds against `main`

This reverts a single line from https://github.com/NVIDIA/FasterTransformer/pull/660 to get builds working again while development on fastertransformer and the triton backend is restructured