### PR TITLE
fix: initialize tiled_prompt_lengths_buf_ to zero in gptneo

### DIFF
--- a/src/fastertransformer/models/gptneox/GptNeoX.cc
+++ b/src/fastertransformer/models/gptneox/GptNeoX.cc
@@ -123,7 +123,7 @@ void GptNeoX<T>::allocateBuffer(
     prompt_learning_weight_batch_ =
         (const T**)(allocator_->reMalloc(prompt_learning_weight_batch_, sizeof(T*) * batchxbeam, false));
     tiled_prompt_lengths_buf_ =
-        (int*)(allocator_->reMalloc(tiled_prompt_lengths_buf_, sizeof(int) * batchxbeam, false));
+        (int*)(allocator_->reMalloc(tiled_prompt_lengths_buf_, sizeof(int) * batchxbeam, true));
 
     tiled_input_ids_buf_ =
         (int*)(allocator_->reMalloc(tiled_input_ids_buf_, sizeof(int) * batchxbeam * max_input_len, true));


### PR DESCRIPTION
I think tiled_prompt_lengths_buf_ should be initialized to zero.
tiled_prompt_lengths_buf_

When invokeMaskPaddingTokens uses uni uninitialized tiled_prompt_lengths_buf_, result should be uncorrect.
https://github.com/Nvidia/FasterTransformer/blob/main/src/fastertransformer/models/gptneox/GptNeoX.cc#L760