### PR TITLE
[Bugfix] GptJ & GptNeoX  batch inference error

### DIFF
--- a/src/fastertransformer/models/gptj/GptJ.cc
+++ b/src/fastertransformer/models/gptj/GptJ.cc
@@ -781,7 +781,7 @@ void GptJ<T>::forward(std::unordered_map<std::string, Tensor>*       output_tens
 
     invokeMaskPaddingTokens(masked_tokens_,
                             input_tensors->at("input_lengths").getPtr<const int>(),  // not_tiled
-                            tiled_prompt_lengths_buf_,
+                            has_prefix_prompt_ ? tiled_prompt_lengths_buf_ : (const int*)nullptr,,
                             max_cache_seq_len,
                             max_input_length + max_prefix_prompt_length,
                             0,

--- a/src/fastertransformer/models/gptneox/GptNeoX.cc
+++ b/src/fastertransformer/models/gptneox/GptNeoX.cc
@@ -757,7 +757,7 @@ void GptNeoX<T>::forward(std::unordered_map<std::string, Tensor>*       output_t
 
     invokeMaskPaddingTokens(masked_tokens_,
                             input_tensors->at("input_lengths").getPtr<const int>(),  // not_tiled
-                            tiled_prompt_lengths_buf_,
+                            has_prefix_prompt_ ? tiled_prompt_lengths_buf_ : (const int*)nullptr,,
                             max_cache_seq_len,
                             max_input_length + max_prefix_prompt_length,
                             0,


### PR DESCRIPTION
GptJ & GptNeoX may generate random outputs when using batch inference mode and no prefix prompt.
The problem is caused by the nullptr check
in https://github.com/NVIDIA/FasterTransformer/blob/f8e42aac45815c5be92c0915b12b9a6652386e8c/src/fastertransformer/kernels/gpt_kernels.cu#L1064