### PR TITLE
Fix shape mismatch on the masked_tokens param in decoder masked multi-head attention kernel.

### DIFF
--- a/src/fastertransformer/kernels/decoder_masked_multihead_attention.h
+++ b/src/fastertransformer/kernels/decoder_masked_multihead_attention.h
@@ -80,8 +80,10 @@ struct Multihead_attention_params_base {
     int batch_size = 0;
     // The beam width
     int beam_width = 0;
-    // The sequence length.
+    // The cache length.
     int memory_max_len = 0;
+    // The whole sequence length, which includes context and output.
+    int session_len = 0;
     // The number of heads (H).
     int num_heads = 0;
     // The hidden dimension per head (Dh).

--- a/src/fastertransformer/layers/attention_layers/DecoderSelfAttentionLayer.cc
+++ b/src/fastertransformer/layers/attention_layers/DecoderSelfAttentionLayer.cc
@@ -50,6 +50,7 @@ void fusedQKV_masked_attention_dispatch(const T*     qkv_buf,
                                         const int    rotary_embedding_dim,
                                         const bool   neox_rotary_style,
                                         const int    memory_max_len,
+                                        const int    session_len,
                                         const int*   prefix_prompt_lengths,
                                         const int    max_prefix_prompt_length,
                                         const int    max_input_len,
@@ -105,6 +106,7 @@ void fusedQKV_masked_attention_dispatch(const T*     qkv_buf,
     params.batch_size               = inference_batch_size;
     params.beam_width               = beam_width;
     params.memory_max_len           = memory_max_len;
+    params.session_len              = session_len;
     params.prefix_prompt_lengths    = prefix_prompt_lengths;
     params.max_prefix_prompt_length = max_prefix_prompt_length;
     params.length_per_sample        = sequence_lengths;  // max_input_length + current output length
@@ -163,6 +165,7 @@ void fusedQKV_masked_attention_dispatch(const T*     qkv_buf,
                                                      const int    rotary_embedding_dim,                                \
                                                      const bool   neox_rotary_style,                                   \
                                                      const int    memory_max_len,                                      \
+                                                     const int    session_len,                                         \
                                                      const int*   prefix_prompt_lengths,                               \
                                                      const int    max_prefix_prompt_length,                            \
                                                      const int    max_input_len,                                       \
@@ -467,7 +470,7 @@ void DecoderSelfAttentionLayer<T>::forward(TensorMap*                output_tens
     //      finished [batch_size] (optional)
     //      total_padding_tokens [batch_size] (optional)
     //      max_input_length [1] on cpu (optional)
-    //      masked_tokens [batch_size, memory_len], (optional)
+    //      masked_tokens [batch_size, session_len], (optional)
     //      cache_indirection [batch_size / beam_width, beam_width, memory_max_len] (optional)
     //      d_prefix_prompt_lengths [batch_size] (optional)
     //      max_prefix_prompt_length [1] on cpu (optional)
@@ -504,6 +507,7 @@ void DecoderSelfAttentionLayer<T>::forward(TensorMap*                output_tens
     const int batch_size     = input_tensors->at("input_query").shape[0];
     const int beam_width     = cache_indir != nullptr ? input_tensors->at("cache_indirection").shape[1] : 1;
     const int memory_max_len = output_tensors->at("key_cache").shape[3];
+    const int session_len    = masked_tokens != nullptr ? input_tensors->at("masked_tokens").shape[1] : 0;
 
     const int* d_prefix_prompt_lengths  = input_tensors->getPtr<int>("d_prefix_prompt_lengths", nullptr);
     const int  max_prefix_prompt_length = input_tensors->getVal<int>("max_prefix_prompt_length", 0);
@@ -596,6 +600,7 @@ void DecoderSelfAttentionLayer<T>::forward(TensorMap*                output_tens
         rotary_embedding_dim_,
         neox_rotary_style_,
         memory_max_len,
+        session_len,
         d_prefix_prompt_lengths,
         max_prefix_prompt_length,
         input_tensors->getVal<int>("max_input_length", 0),

--- a/src/fastertransformer/models/multi_gpu_gpt/ParallelGptDecoder.cc
+++ b/src/fastertransformer/models/multi_gpu_gpt/ParallelGptDecoder.cc
@@ -269,7 +269,7 @@ void ParallelGptDecoder<T>::forward(std::unordered_map<std::string, Tensor>*    
     //      cache_indirection [local_batch_size / beam_width, beam_width, memory_len]
     //          Here, local_batch_size contains the beam_width, so local_batch_size / beam_width
     //          is real local_batch_size. (optional.)
-    //      masked_tokens [local_batch_size, memory_len]
+    //      masked_tokens [local_batch_size, session_len]
     //      linear_bias_slopes [head_num], optional
 
     // output tensors:


### PR DESCRIPTION
This PR addresses an inconsistency in the shape of the masked_tokens array within the decoder's masked multi-head attention kernel. The expected shape of the masked_tokens array is [batch_size, session_length], however, the current implementation in the repo has it shaped as [batch_size, memory_length]. This discrepancy leads to unexpected behaviors when memory_length is not configured to be the same as session_length.

